### PR TITLE
[cmake] remove usage of kodi-platform

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,17 +7,14 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
-find_package(kodiplatform REQUIRED)
 find_package(p8-platform REQUIRED)
 find_package(RapidJSON 1.0.2 REQUIRED)
 
-include_directories(${kodiplatform_INCLUDE_DIRS}
-                    ${p8-platform_INCLUDE_DIRS}
+include_directories(${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}
                     ${RAPIDJSON_INCLUDE_DIRS})
 
-set(DEPLIBS ${kodiplatform_LIBRARIES}
-            ${p8-platform_LIBRARIES})
+set(DEPLIBS ${p8-platform_LIBRARIES})
 
 set(PVRWAIPU_SOURCES
                     src/Curl.cpp

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: kodi-pvr-waipu
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake,
-               libkodiplatform-dev (>= 18.0.0), kodi-addon-dev
+               kodi-addon-dev
 Standards-Version: 3.9.2
 Section: libs
 


### PR DESCRIPTION
The pvr.waipu binary addon does not use kodi-platform.
Remove existing references from CMakeLists.txt and debian/control.