### PR TITLE
Settings: Add check to verify requirements (widevine and network status)

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,10 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.0.2"
+  version="1.0.3"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
-  <requires>@ADDON_DEPENDS@</requires>
+  <requires>@ADDON_DEPENDS@
+    <import addon="script.module.inputstreamhelper" version="0.3.0"/>
+    <import addon="script.module.requests" version="2.3.0"/>
+  </requires>
   <extension
     point="xbmc.pvrclient"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
@@ -26,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.0.3 Settings: Add check to verify requirements (widevine and network status)
 - 1.0.2 Do not show hidden channels
 - 1.0.1 Code cleanup: remove usage of kodi-platform
 - 1.0.0 Fix windows build

--- a/pvr.waipu/resources/check_requirements.py
+++ b/pvr.waipu/resources/check_requirements.py
@@ -1,0 +1,27 @@
+import xbmc
+import xbmcgui
+import inputstreamhelper
+import requests
+import json
+
+
+def getStatus():
+	url = "https://status.wpstr.tv/status?nw=wifi"
+	r = requests.get(url)
+	return r.json()
+
+is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')
+if is_helper.check_inputstream():
+	# widevine installed;
+	xbmc.log("[pvr.waipu] widevine: installed", level=xbmc.LOGDEBUG)
+	widevine_status = "OK - Widevine found."
+else:
+	# widevine not installed; notify user
+	xbmc.log("[pvr.waipu] widevine: not installed", level=xbmc.LOGDEBUG)
+	widevine_status = "Error - Not found!"
+	
+network_status_arr = getStatus()
+network_status = network_status_arr["statusText"]
+
+xbmcgui.Dialog().ok("pvr.waipu - Requirements", "[B]Widevine:[/B] " + widevine_status, "", "[B]Network status:[/B] " + network_status)
+

--- a/pvr.waipu/resources/language/resource.language.de_de/strings.po
+++ b/pvr.waipu/resources/language/resource.language.de_de/strings.po
@@ -26,6 +26,14 @@ msgctxt "#37204"
 msgid "Protocol"
 msgstr "Protokoll"
 
+msgctxt "#37205"
+msgid "Misc"
+msgstr "Sonstiges"
+
+msgctxt "#37206"
+msgid "Check requirements"
+msgstr "Überprüfe Anforderungen"
+
 msgctxt "#37230"
 msgid "Error: Login not possible. Check credentials!"
 msgstr "Fehler: Login nicht möglich. Ungültiger Account!"

--- a/pvr.waipu/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.waipu/resources/language/resource.language.en_gb/strings.po
@@ -26,6 +26,14 @@ msgctxt "#37204"
 msgid "Protocol"
 msgstr ""
 
+msgctxt "#37205"
+msgid "Misc"
+msgstr ""
+
+msgctxt "#37206"
+msgid "Check requirements"
+msgstr ""
+
 msgctxt "#37230"
 msgid "Error: Login not possible. Check credentials!"
 msgstr ""

--- a/pvr.waipu/resources/settings.xml
+++ b/pvr.waipu/resources/settings.xml
@@ -4,6 +4,9 @@
 		<setting id="username" type="text" label="37202" default="" />
 		<setting id="password" type="text" option="hidden" label="37203" default="" />
 		<setting type="sep"/>
-		<setting label="37204" type="labelenum" id="protocol" values="MPEG_DASH|HLS" default="MPEG_DASH" />
+		<setting id="run_check" type="action" label="37206" action="RunScript(special://xbmc/addons/pvr.waipu/resources/check_requirements.py)" />
+		</category>
+	<category label="37205">
+		<setting id="protocol" type="labelenum" label="37204" values="MPEG_DASH|HLS" default="MPEG_DASH" />
 	</category>
 </settings>


### PR DESCRIPTION
This adds a new menu entry to addon configuration to check and install for widevine and to check for waipu network access.
This allows self diagnosis for users if waipu is not working.

New menu entry:
![image](https://user-images.githubusercontent.com/4031504/58617636-f8bd5480-82c0-11e9-94a5-2b132453888e.png)

Check result:
![image](https://user-images.githubusercontent.com/4031504/58617669-0bd02480-82c1-11e9-87c7-8c85ebee777c.png)
