### PR TITLE
Improvement: Select tv channel logo after for-loop

### DIFF
--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -278,15 +278,17 @@ bool WaipuData::LoadChannelData(void)
     	  waipu_channel.strStreamURL = href; // waipu[links][rel=livePlayout]
         continue;
       }
-      if(icon_sd.size() > 0){
-    	  waipu_channel.strIconPath =  icon_sd + "?width=256&height=256" ;
-      }else if(icon_hd.size() > 0){
-    	  waipu_channel.strIconPath =  icon_hd + "?width=256&height=256" ;
-      }else if(icon.size() > 0){
-    	  waipu_channel.strIconPath =  icon + "?width=256&height=256" ;
-      }
       XBMC->Log(LOG_DEBUG, "[channel] link: %s -> %s;",rel.c_str(),href.c_str());
     }
+    if(icon_sd.size() > 0){
+  	  waipu_channel.strIconPath =  icon_sd + "?width=256&height=256" ;
+    }else if(icon_hd.size() > 0){
+  	  waipu_channel.strIconPath =  icon_hd + "?width=256&height=256" ;
+    }else if(icon.size() > 0){
+  	  waipu_channel.strIconPath =  icon + "?width=256&height=256" ;
+    }
+    XBMC->Log(LOG_DEBUG, "[channel] selected channel logo: %s",waipu_channel.strIconPath.c_str());
+
     m_channels.push_back(waipu_channel);
   }
 


### PR DESCRIPTION
Currently, selection of tv channel logo is within the for-loop to iterate over all existing logos. Thus, it is compared and setted multiple times. With this commit, the tv channel logo is selected and assigned after iterated over all icons.
This was the originally intended implementation.