### PR TITLE
[Backport] Improvement: Select tv channel logo out of for-loop

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="0.1.3"
+  version="0.1.4"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 0.1.4 Internal: run channel icon selection only once per tv channel
 - 0.1.3 Settings: Add check to verify requirements (widevine and network status)
 - 0.1.2 Do not show hidden channels
 - 0.1.1 limit displayed channels; show build version; apply channelorder

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -278,15 +278,17 @@ bool WaipuData::LoadChannelData(void)
     	  waipu_channel.strStreamURL = href; // waipu[links][rel=livePlayout]
         continue;
       }
-      if(icon_sd.size() > 0){
-    	  waipu_channel.strIconPath =  icon_sd + "?width=256&height=256" ;
-      }else if(icon_hd.size() > 0){
-    	  waipu_channel.strIconPath =  icon_hd + "?width=256&height=256" ;
-      }else if(icon.size() > 0){
-    	  waipu_channel.strIconPath =  icon + "?width=256&height=256" ;
-      }
       XBMC->Log(LOG_DEBUG, "[channel] link: %s -> %s;",rel.c_str(),href.c_str());
     }
+    if(icon_sd.size() > 0){
+      waipu_channel.strIconPath =  icon_sd + "?width=256&height=256" ;
+    }else if(icon_hd.size() > 0){
+      waipu_channel.strIconPath =  icon_hd + "?width=256&height=256" ;
+    }else if(icon.size() > 0){
+      waipu_channel.strIconPath =  icon + "?width=256&height=256" ;
+    }
+    XBMC->Log(LOG_DEBUG, "[channel] selected channel logo: %s",waipu_channel.strIconPath.c_str());
+
     m_channels.push_back(waipu_channel);
   }
 


### PR DESCRIPTION
backport of #8:

Currently, selection of tv channel logo is within the for-loop to iterate over all existing logos. Thus, it is compared and setted multiple times. With this commit, the tv channel logo is selected and assigned after iterated over all icons.
This was the originally intended implementation.