### PR TITLE
Improve handling of missing login credentials

### DIFF
--- a/src/client.cpp
+++ b/src/client.cpp
@@ -96,7 +96,7 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
 
   XBMC->Log(LOG_DEBUG, "%s - Creating the waipu.tv PVR add-on", __FUNCTION__);
 
-  m_CurStatus     = ADDON_STATUS_UNKNOWN;
+  m_CurStatus     = ADDON_STATUS_NEED_SETTINGS;
   g_strUserPath   = pvrprops->strUserPath;
   g_strClientPath = pvrprops->strClientPath;
 
@@ -104,10 +104,12 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   waipuPassword = "";
   ADDON_ReadSettings();
 
-  m_data = new WaipuData(waipuUsername, waipuPassword);
+  if ( !waipuUsername.empty() && !waipuPassword.empty()){
+	  m_data = new WaipuData(waipuUsername, waipuPassword);
 
-  m_CurStatus = ADDON_STATUS_OK;
-  m_bCreated = true;
+	  m_CurStatus = ADDON_STATUS_OK;
+	  m_bCreated = true;
+  }
   return m_CurStatus;
 }
 


### PR DESCRIPTION
Currently, the waipu plugin always returns "ADDON_STATUS_OK" on addon creation, even if the login credentials are missing.

With this commit, "ADDON_STATUS_NEED_SETTINGS" is returned if username or password are missing. This should be more consistent with the expected addon behavior.