### PR TITLE
Prepare for error handling: Handle HTTP status code in addon

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.0.3"
+  version="1.0.4"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.0.4 Improvements and preparation for error handling
 - 1.0.3 Settings: Add check to verify requirements (widevine and network status)
 - 1.0.2 Do not show hidden channels
 - 1.0.1 Code cleanup: remove usage of kodi-platform

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -135,6 +135,12 @@ bool WaipuData::ApiLogin()
     	return false;
     }
     
+    if (doc.HasMember("error") && doc["error"] == "invalid_request")
+    {
+	XBMC->Log(LOG_ERROR, "[Login] ERROR: invalid credentials?");
+	return false;
+    }
+
     m_apiToken.accessToken = doc["access_token"].GetString();
     XBMC->Log(LOG_DEBUG, "[login check] accessToken: %s;", m_apiToken.accessToken.c_str());
     m_apiToken.refreshToken = doc["refresh_token"].GetString();


### PR DESCRIPTION
The pvr.waipu plugin uses the Kodi curl abstraction for HTTP requests. In the current implementation, Kodi handles error codes (HTTP status code) and returns no data on error. This prevents us to handle error messages and error codes in the pvr plugin.

With this PR, the HTTP status code and response body is forwarded to our plugin. This prepares for better error handling, which will follow in another PR.