### PR TITLE
Prepare for error handling: Handle HTTP status code in addon

### DIFF
--- a/src/Curl.cpp
+++ b/src/Curl.cpp
@@ -89,11 +89,27 @@ string Curl::Request(const string& action, const string& url, const string& post
         entry.second.c_str());
   }
 
+  // we have to set "failonerror" to get error results
+  XBMC->CURLAddOption(file, XFILE::CURL_OPTION_HEADER, "failonerror", "false");
+
   if (!XBMC->CURLOpen(file, XFILE::READ_NO_CACHE))
   {
-    statusCode = 403; //Fake statusCode for now
+    statusCode = -1;
     return "";
   }
+
+  statusCode = 200;
+
+  // get the real statusCode
+  char *tmpCode = XBMC->GetFilePropertyValue(file, XFILE::FILE_PROPERTY_RESPONSE_PROTOCOL, "");
+  std:string tmpRespLine = tmpCode != nullptr ? tmpCode : "";
+  vector<string> resp_protocol_parts = Utils::SplitString(tmpRespLine, ' ', 3);
+  if (resp_protocol_parts.size() == 3)
+  {
+      statusCode = stoi(resp_protocol_parts[1].c_str());
+      XBMC->Log(LOG_DEBUG, "HTTP response code: %i", statusCode);
+  }
+
   int numValues;
   char **cookiesPtr = XBMC->GetFilePropertyValues(file,
       XFILE::FILE_PROPERTY_RESPONSE_HEADER, "set-cookie", &numValues);
@@ -137,7 +153,6 @@ string Curl::Request(const string& action, const string& url, const string& post
   }
 
   XBMC->CloseFile(file);
-  statusCode = 200;
   return body;
 }
 

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -134,7 +134,13 @@ bool WaipuData::ApiLogin()
     	XBMC->Log(LOG_ERROR, "[Login] ERROR: error while parsing json");
     	return false;
     }
-    
+
+    if (doc.HasMember("error") && doc["error"] == "invalid_request")
+    {
+        XBMC->Log(LOG_ERROR, "[Login] ERROR: invalid credentials?");
+        return false;
+    }
+
     m_apiToken.accessToken = doc["access_token"].GetString();
     XBMC->Log(LOG_DEBUG, "[login check] accessToken: %s;", m_apiToken.accessToken.c_str());
     m_apiToken.refreshToken = doc["refresh_token"].GetString();


### PR DESCRIPTION
backport of #12 

The pvr.waipu plugin uses the Kodi curl abstraction for HTTP requests. In the current implementation, Kodi handles error codes (HTTP status code) and returns no data on error. This prevents us to handle error messages and error codes in the pvr plugin.

With this PR, the HTTP status code and response body is forwarded to our plugin. This prepares for better error handling, which will follow in another PR.