### PR TITLE
Leia: Improved error handling related to login problems (no network, invalid credentials)

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="0.1.4"
+  version="0.1.5"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 0.1.5 Improved error handling related to login problems (no network, invalid credentials)
 - 0.1.4 Internal: run channel icon selection only once per tv channel
 - 0.1.3 Settings: Add check to verify requirements (widevine and network status)
 - 0.1.2 Do not show hidden channels

--- a/src/Curl.cpp
+++ b/src/Curl.cpp
@@ -106,7 +106,7 @@ string Curl::Request(const string& action, const string& url, const string& post
   vector<string> resp_protocol_parts = Utils::SplitString(tmpRespLine, ' ', 3);
   if (resp_protocol_parts.size() == 3)
   {
-      statusCode = stoi(resp_protocol_parts[1].c_str());
+      statusCode = Utils::stoiDefault(resp_protocol_parts[1].c_str(), -1);
       XBMC->Log(LOG_DEBUG, "HTTP response code: %i", statusCode);
   }
 

--- a/src/Curl.cpp
+++ b/src/Curl.cpp
@@ -89,11 +89,27 @@ string Curl::Request(const string& action, const string& url, const string& post
         entry.second.c_str());
   }
 
+  // we have to set "failonerror" to get error results
+  XBMC->CURLAddOption(file, XFILE::CURL_OPTION_HEADER, "failonerror", "false");
+
   if (!XBMC->CURLOpen(file, XFILE::READ_NO_CACHE))
   {
-    statusCode = 403; //Fake statusCode for now
+    statusCode = -1;
     return "";
   }
+
+  statusCode = 200;
+
+  // get the real statusCode
+  char *tmpCode = XBMC->GetFilePropertyValue(file, XFILE::FILE_PROPERTY_RESPONSE_PROTOCOL, "");
+  std:string tmpRespLine = tmpCode != nullptr ? tmpCode : "";
+  vector<string> resp_protocol_parts = Utils::SplitString(tmpRespLine, ' ', 3);
+  if (resp_protocol_parts.size() == 3)
+  {
+      statusCode = stoi(resp_protocol_parts[1].c_str());
+      XBMC->Log(LOG_DEBUG, "HTTP response code: %i", statusCode);
+  }
+
   int numValues;
   char **cookiesPtr = XBMC->GetFilePropertyValues(file,
       XFILE::FILE_PROPERTY_RESPONSE_HEADER, "set-cookie", &numValues);
@@ -137,7 +153,6 @@ string Curl::Request(const string& action, const string& url, const string& post
   }
 
   XBMC->CloseFile(file);
-  statusCode = 200;
   return body;
 }
 

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -90,6 +90,11 @@ string WaipuData::HttpRequestToCurl(Curl &curl, const string& action, const stri
 }
 // END CURL helpers from zattoo addon
 
+WAIPU_LOGIN_STATUS WaipuData::GetLoginStatus()
+{
+	return m_login_status;
+}
+
 // returns true if m_apiToken contains valid session
 bool WaipuData::ApiLogin()
 {
@@ -103,6 +108,7 @@ bool WaipuData::ApiLogin()
   {
     // API token exists and is valid, more than x in future
     XBMC->Log(LOG_DEBUG, "[login check] old token still valid");
+    m_login_status = WAIPU_LOGIN_STATUS_OK;
     return true;
   }
   
@@ -119,22 +125,40 @@ bool WaipuData::ApiLogin()
   string jsonString;
   // curl request
   Curl curl;
-  int statusCode;
+  int statusCode = 0;
   curl.AddHeader("User-Agent",WAIPU_USER_AGENT);
   curl.AddHeader("Authorization","Basic YW5kcm9pZENsaWVudDpzdXBlclNlY3JldA==");
   curl.AddHeader("Content-Type","application/x-www-form-urlencoded");
   jsonString = HttpRequestToCurl(curl, "POST", "https://auth.waipu.tv/oauth/token", dataStream.str(), statusCode);
 
-  XBMC->Log(LOG_DEBUG, "[login check] Login-response: %s;", jsonString.c_str());
+  XBMC->Log(LOG_DEBUG, "[login check] Login-response (HTTP %i): %s;", statusCode, jsonString.c_str());
+
+  if (jsonString.length() == 0 && statusCode == -1){
+	  // no network connection?!
+      m_login_status = WAIPU_LOGIN_STATUS_NO_NETWORK;
+      XBMC->Log(LOG_ERROR, "[Login] debug - no network");
+      return false;
+  }else if(statusCode == 401){
+      // invalid credentials
+      m_login_status = WAIPU_LOGIN_STATUS_INVALID_CREDENTIALS;
+      return false;
+  }
 
   if(!jsonString.empty()){
     Document doc;
     doc.Parse(jsonString.c_str());
     if(doc.GetParseError()){
     	XBMC->Log(LOG_ERROR, "[Login] ERROR: error while parsing json");
+    	m_login_status = WAIPU_LOGIN_STATUS_UNKNOWN;
     	return false;
     }
-    
+
+    if (doc.HasMember("error") && doc["error"] == "invalid_request")
+    {
+        XBMC->Log(LOG_ERROR, "[Login] ERROR: invalid credentials?");
+        return false;
+    }
+
     m_apiToken.accessToken = doc["access_token"].GetString();
     XBMC->Log(LOG_DEBUG, "[login check] accessToken: %s;", m_apiToken.accessToken.c_str());
     m_apiToken.refreshToken = doc["refresh_token"].GetString();
@@ -170,9 +194,11 @@ bool WaipuData::ApiLogin()
         	XBMC->Log(LOG_DEBUG, "[jwt] HD channel: %s", user_channel_s.c_str());
         }
     }
+    m_login_status = WAIPU_LOGIN_STATUS_OK;
     return true;
   }
-  // no valid session
+  // no valid session?
+  m_login_status = WAIPU_LOGIN_STATUS_UNKNOWN;
   return false;
 }
 
@@ -196,10 +222,8 @@ WaipuData::~WaipuData(void)
 bool WaipuData::LoadChannelData(void)
 {
 
-  if(!ApiLogin()){
+  if (!ApiLogin()){
     // no valid accessToken
-    XBMC->Log(LOG_DEBUG, "[load data] ERROR - Login invalid");
-    XBMC->QueueNotification(QUEUE_ERROR, "Invalid login credentials?");
     return false;
   }
 
@@ -331,7 +355,7 @@ string WaipuData::GetChannelStreamUrl(int uniqueId, const string& protocol)
     {
       XBMC->Log(LOG_DEBUG, "Get live url for channel %s", thisChannel.strChannelName.c_str());
 
-      if(!ApiLogin()){
+      if (!ApiLogin()){
         // invalid
         XBMC->Log(LOG_DEBUG, "No stream login");
         return "";
@@ -500,7 +524,7 @@ int WaipuData::GetRecordingsAmount(bool bDeleted)
 
 PVR_ERROR WaipuData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
 {
-	if (!ApiLogin()) {
+	if (!ApiLogin()){
 		return PVR_ERROR_SERVER_ERROR;
 	}
 	m_active_recordings_update = true;
@@ -661,7 +685,7 @@ std::string WaipuData::GetRecordingURL(const PVR_RECORDING &recording, const str
 
 PVR_ERROR WaipuData::DeleteRecording(const PVR_RECORDING &recording){
 
-	if(ApiLogin()){
+	if (ApiLogin()){
 		string recording_id = recording.strRecordingId;
 		string request_data = "{\"ids\":[\""+recording_id+"\"]}";
 		XBMC->Log(LOG_DEBUG, "[delete recording] req: %s;", request_data.c_str());
@@ -680,7 +704,7 @@ int WaipuData::GetTimersAmount(void)
 
 PVR_ERROR WaipuData::GetTimers(ADDON_HANDLE handle)
 {
-	if (!ApiLogin()) {
+	if (!ApiLogin()){
 		return PVR_ERROR_SERVER_ERROR;
 	}
 
@@ -784,7 +808,7 @@ PVR_ERROR WaipuData::GetTimers(ADDON_HANDLE handle)
 
 PVR_ERROR WaipuData::DeleteTimer(const PVR_TIMER &timer){
 
-	if(ApiLogin()){
+	if (ApiLogin()){
 		int timer_id = timer.iClientIndex;
 		string request_data = "{\"ids\":[\""+to_string(timer_id)+"\"]}";
 		XBMC->Log(LOG_DEBUG, "[delete timer] req: %s;", request_data.c_str());
@@ -798,7 +822,7 @@ PVR_ERROR WaipuData::DeleteTimer(const PVR_TIMER &timer){
 
 PVR_ERROR WaipuData::AddTimer(const PVR_TIMER &timer){
 
-	if(ApiLogin()){
+	if (ApiLogin()){
 		// {"programId":"_1051966761","channelId":"PRO7","startTime":"2019-02-03T18:05:00.000Z","stopTime":"2019-02-03T19:15:00.000Z"}
 		for(const auto& channel : m_channels){
 			if(channel.iUniqueId != timer.iClientChannelUid)

--- a/src/WaipuData.h
+++ b/src/WaipuData.h
@@ -33,6 +33,13 @@ using namespace std;
  */
 static const std::string WAIPU_USER_AGENT = "kodi plugin for waipu (pvr.waipu)";
 
+enum WAIPU_LOGIN_STATUS {
+	WAIPU_LOGIN_STATUS_OK,
+	WAIPU_LOGIN_STATUS_INVALID_CREDENTIALS,
+	WAIPU_LOGIN_STATUS_NO_NETWORK,
+	WAIPU_LOGIN_STATUS_UNKNOWN
+};
+
 struct WaipuApiToken
 {
   string      accessToken;
@@ -85,6 +92,7 @@ public:
   PVR_ERROR AddTimer(const PVR_TIMER &timer);
 
   std::string GetLicense(void);
+  WAIPU_LOGIN_STATUS GetLoginStatus(void);
 
 protected:
   string HttpGet(const string& url);
@@ -104,4 +112,5 @@ private:
   int							   m_recordings_count;
   bool							   m_active_recordings_update;
   std::vector<string>			   m_user_channels;
+  WAIPU_LOGIN_STATUS               m_login_status = WAIPU_LOGIN_STATUS_UNKNOWN;
 };

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -107,8 +107,18 @@ ADDON_STATUS ADDON_Create(void* hdl, void* props)
   if (!waipuUsername.empty() && !waipuPassword.empty()){
     m_data = new WaipuData(waipuUsername, waipuPassword);
 
-    m_CurStatus = ADDON_STATUS_OK;
-    m_bCreated = true;
+    if (m_data->GetLoginStatus() == WAIPU_LOGIN_STATUS_OK){
+       m_CurStatus = ADDON_STATUS_OK;
+       m_bCreated = true;
+    }else if (m_data->GetLoginStatus() == WAIPU_LOGIN_STATUS_NO_NETWORK){
+       m_CurStatus = ADDON_STATUS_LOST_CONNECTION; // is this the right status?
+       XBMC->Log(LOG_DEBUG, "[load data] ERROR - Network Issue");
+       XBMC->QueueNotification(QUEUE_ERROR, "No network connection?");
+    }else if (m_data->GetLoginStatus() == WAIPU_LOGIN_STATUS_INVALID_CREDENTIALS){
+    	m_CurStatus = ADDON_STATUS_NEED_SETTINGS;
+        XBMC->Log(LOG_DEBUG, "[load data] ERROR - Login invalid");
+        XBMC->QueueNotification(QUEUE_ERROR, "Invalid login credentials!");
+    }
   }
   return m_CurStatus;
 }


### PR DESCRIPTION
This PR makes use of the returned HTTP status code. It handles login/connection problems.

I am currently not sure if the implementation of APILogin() and _m_login_status_ is a clean solution. Maybe there is a better solution I will implement in Matrix. I think this is good to go into inofficial/testing Leia version of pvr.waipu.

An implementation for Matrix branch will follow after it is tested by our Leia testers.