### PR TITLE
Make CURL HTTP status code parsing more robust, like in #14

### DIFF
--- a/src/Curl.cpp
+++ b/src/Curl.cpp
@@ -106,7 +106,7 @@ string Curl::Request(const string& action, const string& url, const string& post
   tmpRespLine = tmpCode != nullptr ? tmpCode : "";
   vector<string> resp_protocol_parts = Utils::SplitString(tmpRespLine, ' ', 3);
   if (resp_protocol_parts.size() == 3){
-      statusCode = stoi(resp_protocol_parts[1].c_str());
+      statusCode = Utils::stoiDefault(resp_protocol_parts[1].c_str(), -1);
       XBMC->Log(LOG_DEBUG, "HTTP response code: %i.", statusCode);
   }
   XBMC->FreeString(tmpCode);


### PR DESCRIPTION
Just a small change: When parsing the HTTP status code, we assume that at position 2 ("HTTP/1.1 200 OK", split by space) is the HTTP status code number and parse it as int.

With this small change, we make parsing more robust by setting a default value if it is not an integer.