### PR TITLE
Requirements check: show message if no internet connection

### DIFF
--- a/pvr.waipu/resources/check_requirements.py
+++ b/pvr.waipu/resources/check_requirements.py
@@ -7,7 +7,10 @@ import json
 
 def getStatus():
 	url = "https://status.wpstr.tv/status?nw=wifi"
-	r = requests.get(url)
+	try:
+	  r = requests.get(url)
+	except requests.ConnectionError:
+	  return {"statusText" : "No internet connection!"}
 	return r.json()
 
 is_helper = inputstreamhelper.Helper('mpd', drm='com.widevine.alpha')


### PR DESCRIPTION
backport of #16 

Handle missing internet connection/connection error in requirements check.

Old behavior on missing internet: 
check crashes and an error notification appears

Behavior with this PR on missing internet:
Diagnosis popup shows message 'No internet connection!'
