### PR TITLE
Handle login problems depending on API response/status code

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.0.5"
+  version="1.0.6"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.0.6 Improved error handling related to login problems (no network, invalid credentials)
 - 1.0.5 Settings check requirements: handle network issues
 - 1.0.4 Improvements and preparation for error handling
 - 1.0.3 Settings: Add check to verify requirements (widevine and network status)

--- a/src/WaipuData.h
+++ b/src/WaipuData.h
@@ -33,6 +33,13 @@ using namespace std;
  */
 static const std::string WAIPU_USER_AGENT = "kodi plugin for waipu (pvr.waipu)";
 
+enum WAIPU_LOGIN_STATUS {
+  WAIPU_LOGIN_STATUS_OK,
+  WAIPU_LOGIN_STATUS_INVALID_CREDENTIALS,
+  WAIPU_LOGIN_STATUS_NO_NETWORK,
+  WAIPU_LOGIN_STATUS_UNKNOWN
+};
+
 struct WaipuApiToken
 {
   string      accessToken;
@@ -85,6 +92,7 @@ public:
   PVR_ERROR AddTimer(const PVR_TIMER &timer);
 
   std::string GetLicense(void);
+  WAIPU_LOGIN_STATUS GetLoginStatus(void);
 
 protected:
   string HttpGet(const string& url);
@@ -100,8 +108,9 @@ private:
   std::string                      username;
   std::string                      password;
   WaipuApiToken                    m_apiToken;
-  std::string					   m_license;
-  int							   m_recordings_count;
-  bool							   m_active_recordings_update;
-  std::vector<string>			   m_user_channels;
+  std::string                      m_license;
+  int                              m_recordings_count;
+  bool                             m_active_recordings_update;
+  std::vector<string>              m_user_channels;
+  WAIPU_LOGIN_STATUS               m_login_status = WAIPU_LOGIN_STATUS_UNKNOWN;
 };


### PR DESCRIPTION
Ported from PR #14 

Before this PR, the error cause is guessed and handled in ApiLogin(). With this PR, we determine the cause in a more sophisticated way, based on the HTTP status code and the error message.

A method GetLoginStatus() is added to retrieve the login status and issues. This allows to set a better ADDON_STATUS on errors.

Note: On missing network connection, currently ADDON_STATUS_LOST_CONNECTION is returned. I am not sure if this is an appropriate state, since kodi seems not to restart this plugin on network connection.