### PR TITLE
Add workaround for broken o2 API response

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.0.6"
+  version="1.0.7"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.0.7 Add workaround for O2 Accounts
 - 1.0.6 Improved error handling related to login problems (no network, invalid credentials)
 - 1.0.5 Settings check requirements: handle network issues
 - 1.0.4 Improvements and preparation for error handling

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -159,3 +159,11 @@ int Utils::stoiDefault(std::string str, int i)
 		return i;
 	}
 }
+
+bool Utils::ends_with(std::string const &haystack, std::string const &end) {
+    if (haystack.length() >= end.length()) {
+        return (0 == haystack.compare (haystack.length() - end.length(), end.length(), end));
+    } else {
+        return false;
+    }
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -24,4 +24,5 @@ public:
   static std::string ltrim(std::string str, const std::string chars = "\t\n\v\f\r _");
   static int GetIDDirty(std::string str);
   static int stoiDefault(std::string str, int i);
+  static bool ends_with (std::string const &haystack, std::string const &end);
 };

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -157,6 +157,12 @@ bool WaipuData::ApiLogin()
 	XBMC->Log(LOG_ERROR, "[Login] ERROR: invalid credentials?");
 	m_login_status = WAIPU_LOGIN_STATUS_INVALID_CREDENTIALS;
 	return false;
+    }else if (doc.HasMember("error")){
+ 	// unhandled error -> handle if known
+ 	string err = doc["error"].GetString();
+ 	XBMC->Log(LOG_ERROR, "[Login] ERROR: (%s)", err.c_str());
+ 	m_login_status = WAIPU_LOGIN_STATUS_UNKNOWN;
+ 	return false;
     }
 
     m_apiToken.accessToken = doc["access_token"].GetString();
@@ -172,8 +178,21 @@ bool WaipuData::ApiLogin()
     	XBMC->Log(LOG_DEBUG, "[jwt] middle: %s", jwt_arr.at(1).c_str());
     	string jwt_payload = base64_decode(jwt_arr.at(1));
     	XBMC->Log(LOG_DEBUG, "[jwt] payload: %s", jwt_payload.c_str());
-        Document jwt_doc;
+
+        if (!Utils::ends_with(jwt_payload, "}}}") && jwt_payload.size() > 0 && Utils::ends_with(jwt_payload, "subscription\":\"")){
+            // this is a dirty hack. It seems that for some accounts the subscription is cutted
+            jwt_payload = jwt_payload + "O2\"}}}";
+        }
+
+    	Document jwt_doc;
         jwt_doc.Parse(jwt_payload.c_str());
+
+        if(jwt_doc.HasParseError()){
+            m_login_status = WAIPU_LOGIN_STATUS_UNKNOWN;
+            XBMC->Log(LOG_ERROR, "[jwt_doc] ERROR: error while parsing json");
+            return false;
+        }
+
         string userHandle = jwt_doc["userHandle"].GetString();
         XBMC->Log(LOG_DEBUG, "[jwt] userHandle: %s", userHandle.c_str());
         // generate the license


### PR DESCRIPTION
For O2 waipu accounts, the api reponse is broken and ends after subscription. This breaks our json parsing. This workaround fixes the json before parsing. It should have no impact on valid API responses