### PR TITLE
[backport] Add workaround for broken o2 API response

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="0.1.6"
+  version="0.1.7"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 0.1.7 Add workaround for O2 Accounts
 - 0.1.6 Settings check requirements: handle network issue
 - 0.1.5 Improved error handling related to login problems (no network, invalid credentials)
 - 0.1.4 Internal: run channel icon selection only once per tv channel

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -160,3 +160,11 @@ int Utils::stoiDefault(std::string str, int i)
 		return i;
 	}
 }
+
+bool Utils::ends_with(std::string const &haystack, std::string const &end) {
+    if (haystack.length() >= end.length()) {
+        return (0 == haystack.compare (haystack.length() - end.length(), end.length(), end));
+    } else {
+        return false;
+    }
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -24,4 +24,5 @@ public:
   static std::string ltrim(std::string str, const std::string chars = "\t\n\v\f\r _");
   static int GetIDDirty(std::string str);
   static int stoiDefault(std::string str, int i);
+  static bool ends_with (std::string const &haystack, std::string const &end);
 };


### PR DESCRIPTION
backport of #19 

For O2 waipu accounts, the api reponse is broken and ends after subscription. This breaks our json parsing. This workaround fixes the json before parsing. It should have no impact on valid API responses