### PR TITLE
[Leia] Fix: recordings are not displayed

### DIFF
--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -544,12 +544,17 @@ int WaipuData::GetRecordingsAmount(bool bDeleted)
 
 PVR_ERROR WaipuData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
 {
-	if (!ApiLogin()){
-		return PVR_ERROR_SERVER_ERROR;
-	}
-	m_active_recordings_update = true;
+    if (!ApiLogin()){
+        return PVR_ERROR_SERVER_ERROR;
+    }
+    m_active_recordings_update = true;
 
-    string jsonRecordings = HttpGet("https://recording.waipu.tv/api/recordings");
+    Curl curl;
+    int statusCode;
+    curl.AddHeader("User-Agent",WAIPU_USER_AGENT);
+    curl.AddHeader("Authorization","Bearer "+m_apiToken.accessToken);
+    curl.AddHeader("Accept","application/vnd.waipu.recordings-v2+json");
+    string jsonRecordings = HttpRequestToCurl(curl, "GET", "https://recording.waipu.tv/api/recordings", "", statusCode);
     XBMC->Log(LOG_DEBUG, "[recordings] %s",jsonRecordings.c_str());
 
     jsonRecordings = "{\"result\": "+jsonRecordings+"}";


### PR DESCRIPTION
Due to an API change, no recordings were returned. With this fix, the required accept header is set and recordings are displayed again.