### PR TITLE
Add settings menu option to (re-)install widevine

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.0.8"
+  version="1.1.0"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.1.0 Fix timers not displayed; Add option to install widevine
 - 1.0.8 Update build sytem version; change header include way
 - 1.0.7 Add workaround for O2 Accounts
 - 1.0.6 Improved error handling related to login problems (no network, invalid credentials)

--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -5,7 +5,7 @@
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
-    <import addon="script.module.inputstreamhelper" version="0.3.0"/>
+    <import addon="script.module.inputstreamhelper" version="0.4.1"/>
     <import addon="script.module.requests" version="2.3.0"/>
   </requires>
   <extension

--- a/pvr.waipu/resources/language/resource.language.de_de/strings.po
+++ b/pvr.waipu/resources/language/resource.language.de_de/strings.po
@@ -34,6 +34,10 @@ msgctxt "#37206"
 msgid "Check requirements"
 msgstr "Überprüfe Anforderungen"
 
+msgctxt "#37207"
+msgid "(Re)install Widevine CDM library"
+msgstr "Widevine CDM Bibliothek (erneut) installieren"
+
 msgctxt "#37230"
 msgid "Error: Login not possible. Check credentials!"
 msgstr "Fehler: Login nicht möglich. Ungültiger Account!"

--- a/pvr.waipu/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.waipu/resources/language/resource.language.en_gb/strings.po
@@ -34,6 +34,10 @@ msgctxt "#37206"
 msgid "Check requirements"
 msgstr ""
 
+msgctxt "#37207"
+msgid "(Re)install Widevine CDM library..."
+msgstr ""
+
 msgctxt "#37230"
 msgid "Error: Login not possible. Check credentials!"
 msgstr ""

--- a/pvr.waipu/resources/settings.xml
+++ b/pvr.waipu/resources/settings.xml
@@ -4,6 +4,7 @@
 		<setting id="username" type="text" label="37202" default="" />
 		<setting id="password" type="text" option="hidden" label="37203" default="" />
 		<setting type="sep"/>
+		<setting id="install_widevine" type="action" label="37207" action="RunScript(script.module.inputstreamhelper, widevine_install)" visible="!system.platform.android"/>
 		<setting id="run_check" type="action" label="37206" action="RunScript(special://xbmc/addons/pvr.waipu/resources/check_requirements.py)" />
 		</category>
 	<category label="37205">


### PR DESCRIPTION
Use new inputstreamhelper API (https://github.com/emilsvennesson/script.module.inputstreamhelper/pull/141) to provide widevine install from pvr.waipu addon settings.

Screenshot:
![image](https://user-images.githubusercontent.com/4031504/64080184-7d20d880-ccf1-11e9-9c53-fa00be808b7c.png)

