### PR TITLE
Improvements: Casting and base64 decoding

### DIFF
--- a/src/Base64.cpp
+++ b/src/Base64.cpp
@@ -36,7 +36,7 @@ static const std::string BASE64_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 static inline bool is_base64(unsigned char c)
 {
-  return (isalnum(c) || (c == '+') || (c == '/'));
+  return (isalnum(c) || (c == '+') || (c == '/') || (c == '_') || (c == '-'));
 }
 
 std::string base64_encode(char const* bytes_to_encode, unsigned int in_len)
@@ -93,7 +93,20 @@ std::string base64_decode(std::string const& encoded_string)
 
   while (in_len-- && (encoded_string[in_] != '=') && is_base64(encoded_string[in_]))
   {
-    char_array_4[i++] = encoded_string[in_];
+    if (encoded_string[in_] == '_')
+    {
+      // workaround for base64 URL safe, see: rfc4648
+      char_array_4[i++] = '/';
+    }
+    else if (encoded_string[in_] == '-')
+    {
+      // workaround for base64 URL safe, see: rfc4648
+      char_array_4[i++] = '+';
+    }
+    else
+    {
+      char_array_4[i++] = encoded_string[in_];
+    }
     in_++;
     if (i == 4)
     {

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -196,14 +196,6 @@ bool WaipuData::ApiLogin()
       string jwt_payload = base64_decode(jwt_arr.at(1));
       XBMC->Log(LOG_DEBUG, "[jwt] payload: %s", jwt_payload.c_str());
 
-      if (!Utils::ends_with(jwt_payload, "}}}") && jwt_payload.size() > 0 &&
-          Utils::ends_with(jwt_payload, "subscription\":\""))
-      {
-        // this is a dirty hack. It seems that for some accounts the
-        // subscription is cutted
-        jwt_payload = jwt_payload + "O2\"}}}";
-      }
-
       Document jwt_doc;
       jwt_doc.Parse(jwt_payload.c_str());
 

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -156,7 +156,7 @@ extern "C"
 
     if (name == "username")
     {
-      string username = (const char*)settingValue;
+      string username = static_cast<const char*>(settingValue);
       if (username != waipuUsername)
       {
         waipuUsername = username;
@@ -166,7 +166,7 @@ extern "C"
 
     if (name == "password")
     {
-      string password = (const char*)settingValue;
+      string password = static_cast<const char*>(settingValue);
       if (password != waipuPassword)
       {
         waipuPassword = password;


### PR DESCRIPTION
Two improvements discovered when implementing the [O2 authentiction](https://github.com/flubshi/pvr.waipu/tree/matrix_implement_o2_auth).

I think, static casting is self explaining.

The base64 decoding is improved to support the characters underscore and minus, which are used for URL safe base64 encoded content. This enables us to remove the dirty O2 workaround, which is anyway no longer working.