### PR TITLE
Improvement: Allow cookie handling for curl on redirects

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.2.0"
+  version="1.2.1"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.2.1 Internal improvements to prepare for O2 authentication
 - 1.1.0 Fix timers not displayed; Add option to install widevine
 - 1.0.8 Update build sytem version; change header include way
 - 1.0.7 Add workaround for O2 Accounts

--- a/src/Curl.h
+++ b/src/Curl.h
@@ -1,8 +1,16 @@
 /*
- * taken from pvr:zattoo
+ * originally taken from pvr.zattoo
  */
+#include <list>
 #include <map>
 #include <string>
+
+struct Cookie
+{
+  std::string host;
+  std::string name;
+  std::string value;
+};
 
 class Curl
 {
@@ -16,16 +24,26 @@ public:
   virtual void AddOption(const std::string& name, const std::string& value);
   virtual void ResetHeaders();
   virtual std::string GetCookie(const std::string& name);
+  virtual void SetCookie(const std::string& host,
+                         const std::string& name,
+                         const std::string& value);
   virtual std::string GetLocation() { return location; }
+  virtual void SetRedirectLimit(int limit) { redirectLimit = limit; }
 
 private:
+  virtual void* PrepareRequest(const std::string& action,
+                               const std::string& url,
+                               const std::string& postData);
+  virtual void ParseCookies(void* file, const std::string& host);
   virtual std::string Request(const std::string& action,
                               const std::string& url,
                               const std::string& postData,
                               int& statusCode);
+  virtual std::string ParseHostname(const std::string& url);
   std::string Base64Encode(unsigned char const* in, unsigned int in_len, bool urlEncode);
   std::map<std::string, std::string> headers;
   std::map<std::string, std::string> options;
-  std::map<std::string, std::string> cookies;
+  std::list<Cookie> cookies;
   std::string location;
+  int redirectLimit = 8;
 };


### PR DESCRIPTION
When implementing [Authentication for O2](https://github.com/flubshi/pvr.waipu/commits/matrix_curl_redirect) it became necessary to keep session cookies for authentication over multiple redirects and HTTP requests. After getting session tokens, a login form has to be submitted and on success, the user is redirected back to the start page, while session cookies are required on this redirecting steps. This PR does not contain the implementation of the authentication. Instead, it prepares our curl implementation. 

Since I found no way to setup the Kodi curl implementation, I decided to use the following approach:
- set redirect limit to 0 (Kodis curl should not handle redirects for us)
- parse response headers for redirects
- parse responses for cookies
- set stored cookies for redirect, follow redirects


This implementation lacks in a few points:
- cookie host is taken from location (set-cookie specification is ignored)
- not all redirect codes are handled

It means, this approach should not be copied by others, since it is not a good handling. But I think it is sufficient for our purpose.
 
