### PR TITLE
Matrix fix ubuntu/debian packaging

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,8 @@ Source: kodi-pvr-waipu
 Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake,
-               kodi-addon-dev, libp8-platform-dev
+               kodi-addon-dev, libp8-platform-dev,
+               rapidjson-dev (>= 1.0.2)
 Standards-Version: 3.9.2
 Section: libs
 

--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.2.2"
+  version="1.2.3"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.2.3 Fix Ubuntu packaging: add rapidjson dependency
 - 1.2.2 Fix Debian/Ubuntu packaging (thx Rechi)
 - 1.2.1 Internal improvements to prepare for O2 authentication
 - 1.1.0 Fix timers not displayed; Add option to install widevine


### PR DESCRIPTION
Add rapidjson-dev dependency for ubuntu packaging. Discovered by @Rechi in #39 