### PR TITLE
Matrix fix ubuntu packaging (2)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,8 +3,8 @@ Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake,
                kodi-addon-dev, libp8-platform-dev,
-               rapidjson-dev (>= 1.0.2)
-Standards-Version: 3.9.2
+               rapidjson-dev
+Standards-Version: 3.9.4
 Section: libs
 
 Package: kodi-pvr-waipu

--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.2.3"
+  version="1.2.4"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.2.4 Fix Ubuntu packaging: adjust rapidjson dependency
 - 1.2.3 Fix Ubuntu packaging: add rapidjson dependency
 - 1.2.2 Fix Debian/Ubuntu packaging (thx Rechi)
 - 1.2.1 Internal improvements to prepare for O2 authentication


### PR DESCRIPTION
pvr.waipu is packaged for Ubuntu Bionic and newer. Due to an older rapidjson package, it was not build for Xenial.
This PR removes the minimum version for rapidjson-dev dependency, as it should work with the older version of rapidjson-dev in Xenial repos as well. (pvr.zattoo is available for Xenial too and most of the pvr.waipu code is inspired by the zattoo plugin ;) ) 