### PR TITLE
Fix Debian: Set rapidjson dependency >=1.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 
 find_package(Kodi REQUIRED)
 find_package(p8-platform REQUIRED)
-find_package(RapidJSON 1.0.2 REQUIRED)
+find_package(RapidJSON 1.1.0 REQUIRED)
 
 include_directories(${p8-platform_INCLUDE_DIRS}
                     ${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways

--- a/FindRapidJSON.cmake
+++ b/FindRapidJSON.cmake
@@ -9,18 +9,15 @@
 # RAPIDJSON_INCLUDE_DIRS - the RapidJSON parser include directory
 #
 
+find_package(PkgConfig)
 if(PKG_CONFIG_FOUND)
-  pkg_check_modules(PC_RapidJSON RapidJSON>=1.0.2 QUIET)
+  pkg_check_modules(PC_RapidJSON RapidJSON>=${RapidJSON_FIND_VERSION} QUIET)
 endif()
 
-if(CORE_SYSTEM_NAME STREQUAL windows OR CORE_SYSTEM_NAME STREQUAL windowsstore)
-  set(RapidJSON_VERSION 1.1.0)
+if(PC_RapidJSON_VERSION)
+  set(RapidJSON_VERSION ${PC_RapidJSON_VERSION})
 else()
-  if(PC_RapidJSON_VERSION)
-    set(RapidJSON_VERSION ${PC_RapidJSON_VERSION})
-  else()
-    find_package(RapidJSON 1.1.0 CONFIG REQUIRED QUIET)
-  endif()
+  find_package(RapidJSON ${RapidJSON_FIND_VERSION} CONFIG REQUIRED QUIET)
 endif()
 
 find_path(RapidJSON_INCLUDE_DIR NAMES rapidjson/rapidjson.h

--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Priority: extra
 Maintainer: Nobody <nobody@kodi.tv>
 Build-Depends: debhelper (>= 9.0.0), cmake,
                kodi-addon-dev, libp8-platform-dev,
-               rapidjson-dev
+               rapidjson-dev (>= 1.1.0)
 Standards-Version: 3.9.4
 Section: libs
 


### PR DESCRIPTION
For Xenial ppa, build still fails due to inconsistent rapidjson version dependency.

In our implementation, we use `GetArray()`, which was introduced in rapidjson-1.1.0. (See [here](https://rapidjson.org/md_doc_tutorial.html))

This PR sets required minimum version of rapidjson to 1.1.0.