### PR TITLE
Implement O2 authentication

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.2.4"
+  version="1.3.0"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.3.0 Implement O2 authentication
 - 1.2.4 Fix Ubuntu packaging: adjust rapidjson dependency
 - 1.2.3 Fix Ubuntu packaging: add rapidjson dependency
 - 1.2.2 Fix Debian/Ubuntu packaging (thx Rechi)

--- a/pvr.waipu/resources/language/resource.language.de_de/strings.po
+++ b/pvr.waipu/resources/language/resource.language.de_de/strings.po
@@ -35,8 +35,20 @@ msgid "Check requirements"
 msgstr "Überprüfe Anforderungen"
 
 msgctxt "#37207"
-msgid "(Re)install Widevine CDM library"
-msgstr "Widevine CDM Bibliothek (erneut) installieren"
+msgid "(Re)install Widevine CDM library..."
+msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+
+msgctxt "#37208"
+msgid "Provider"
+msgstr "Anbieter"
+
+msgctxt "#37209"
+msgid "Waipu.tv"
+msgstr "Waipu.tv"
+
+msgctxt "#37210"
+msgid "O2 TV"
+msgstr "O2 TV (beta)"
 
 msgctxt "#37230"
 msgid "Error: Login not possible. Check credentials!"

--- a/pvr.waipu/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.waipu/resources/language/resource.language.en_gb/strings.po
@@ -38,6 +38,18 @@ msgctxt "#37207"
 msgid "(Re)install Widevine CDM library..."
 msgstr ""
 
+msgctxt "#37208"
+msgid "Provider"
+msgstr ""
+
+msgctxt "#37209"
+msgid "Waipu.tv"
+msgstr ""
+
+msgctxt "#37210"
+msgid "O2 TV (beta)"
+msgstr ""
+
 msgctxt "#37230"
 msgid "Error: Login not possible. Check credentials!"
 msgstr ""

--- a/pvr.waipu/resources/settings.xml
+++ b/pvr.waipu/resources/settings.xml
@@ -3,6 +3,7 @@
     <category label="37201">
 		<setting id="username" type="text" label="37202" default="" />
 		<setting id="password" type="text" option="hidden" label="37203" default="" />
+		<setting id="provider_select" label="37208" type="enum" lvalues="37209|37210" default="0" />
 		<setting type="sep"/>
 		<setting id="install_widevine" type="action" label="37207" action="RunScript(script.module.inputstreamhelper, widevine_install)" visible="!system.platform.android"/>
 		<setting id="run_check" type="action" label="37206" action="RunScript(special://xbmc/addons/pvr.waipu/resources/check_requirements.py)" />

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -173,3 +173,18 @@ bool Utils::ends_with(std::string const& haystack, std::string const& end)
     return false;
   }
 }
+
+
+std::string Utils::ReplaceAll(std::string str,
+                              const std::string& search,
+                              const std::string& replace)
+{
+  // taken from: https://stackoverflow.com/questions/2896600/how-to-replace-all-occurrences-of-a-character-in-string
+  size_t start_pos = 0;
+  while ((start_pos = str.find(search, start_pos)) != std::string::npos)
+  {
+    str.replace(start_pos, search.length(), replace);
+    start_pos += replace.length();
+  }
+  return str;
+}

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -26,4 +26,5 @@ public:
   static int GetIDDirty(std::string str);
   static int stoiDefault(std::string str, int i);
   static bool ends_with(std::string const& haystack, std::string const& end);
+  static std::string ReplaceAll(std::string str, const std::string& search, const std::string& replace);
 };

--- a/src/WaipuData.h
+++ b/src/WaipuData.h
@@ -69,7 +69,7 @@ struct WaipuEPGMappingEntry
 class WaipuData
 {
 public:
-  WaipuData(const std::string& user, const std::string& pass);
+  WaipuData(const std::string& user, const std::string& pass, const WAIPU_PROVIDER provider);
   virtual ~WaipuData(void);
 
   int GetChannelsAmount(void);
@@ -104,9 +104,12 @@ protected:
   string HttpRequestToCurl(
       Curl& curl, const string& action, const string& url, const string& postData, int& statusCode);
   bool ApiLogin();
+  bool WaipuLogin();
+  bool O2Login();
   bool LoadChannelData(void);
 
 private:
+  bool ParseAccessToken(void);
   std::vector<WaipuChannel> m_channels;
   std::string username;
   std::string password;
@@ -116,4 +119,5 @@ private:
   bool m_active_recordings_update;
   std::vector<string> m_user_channels;
   WAIPU_LOGIN_STATUS m_login_status = WAIPU_LOGIN_STATUS_UNKNOWN;
+  WAIPU_PROVIDER provider;
 };

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -45,6 +45,7 @@ std::string g_strClientPath = "";
 
 std::string waipuUsername;
 std::string waipuPassword;
+WAIPU_PROVIDER provider = WAIPU_PROVIDER_WAIPU;
 std::string protocol;
 
 CHelper_libXBMC_addon* XBMC = NULL;
@@ -70,6 +71,14 @@ extern "C"
     if (XBMC->GetSetting("protocol", &buffer))
     {
       protocol = buffer;
+    }
+    if (XBMC->GetSetting("provider_select", &intBuffer))
+    {
+	if(intBuffer == 0){
+	    provider = WAIPU_PROVIDER_WAIPU;
+	}else{
+	    provider = WAIPU_PROVIDER_O2;
+	}
     }
     XBMC->Log(LOG_DEBUG, "End Readsettings");
   }
@@ -108,7 +117,7 @@ extern "C"
 
     if (!waipuUsername.empty() && !waipuPassword.empty())
     {
-      m_data = new WaipuData(waipuUsername, waipuPassword);
+      m_data = new WaipuData(waipuUsername, waipuPassword, provider);
 
       switch (m_data->GetLoginStatus())
       {
@@ -170,6 +179,26 @@ extern "C"
       if (password != waipuPassword)
       {
         waipuPassword = password;
+        return ADDON_STATUS_NEED_RESTART;
+      }
+    }
+
+    if (name == "provider_select")
+    {
+      int tmpProviderID = *static_cast<const int*>(settingValue);
+      WAIPU_PROVIDER tmpProvider;
+      if (tmpProviderID == 0)
+      {
+        tmpProvider = WAIPU_PROVIDER_WAIPU;
+      }
+      else
+      {
+        tmpProvider = WAIPU_PROVIDER_O2;
+      }
+
+      if (tmpProvider != provider)
+      {
+        provider = tmpProvider;
         return ADDON_STATUS_NEED_RESTART;
       }
     }

--- a/src/client.h
+++ b/src/client.h
@@ -28,3 +28,9 @@ extern std::string g_strUserPath;
 extern std::string g_strClientPath;
 extern ADDON::CHelper_libXBMC_addon* XBMC;
 extern CHelper_libXBMC_pvr* PVR;
+
+enum WAIPU_PROVIDER
+{
+  WAIPU_PROVIDER_WAIPU,
+  WAIPU_PROVIDER_O2
+};


### PR DESCRIPTION
This PR implements O2 authentication for pvr.waipu.

A while ago, it was possible to use O2 TV credentials with waipu API. The API has changed and authentication using O2 credentials for waipu API is no longer possible. Instead, one has to authenticate against O2 SSO and retrieve an waipu API token (user_token). Using this token, the API can be used the same way as for an waipu token.

Besides entering the credentials, the user has now to select to authentication provider (Waipu.tv or O2 TV) in addon settings.