### PR TITLE
Leia channel unique id

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="0.2.0"
+  version="0.2.1"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>
@@ -29,6 +29,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 0.2.1 Fix channel order: calculate unique channel id
 - 0.2.0 Fix timers not displayed; Add option to install widevine
 - 0.1.9 Update build sytem version; change header include way
 - 0.1.8 Drop HLS support

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -151,6 +151,15 @@ int Utils::GetIDDirty(std::string str)
   return rand() % 99999 + 1;
 }
 
+int Utils::GetChannelId(const char* strChannelName)
+{
+  int iId = 0;
+  int c;
+  while ((c = *strChannelName++))
+    iId = ((iId << 5) + iId) + c; /* iId * 33 + c */
+  return abs(iId);
+}
+
 int Utils::stoiDefault(std::string str, int i)
 {
   try

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -24,6 +24,7 @@ public:
   static time_t StringToTime(std::string timeString);
   static std::string ltrim(std::string str, const std::string chars = "\t\n\v\f\r _");
   static int GetIDDirty(std::string str);
+  static int GetChannelId(const char* strChannelName);
   static int stoiDefault(std::string str, int i);
   static bool ends_with(std::string const& haystack, std::string const& end);
 };

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -326,9 +326,9 @@ bool WaipuData::LoadChannelData(void)
     waipu_channel.waipuID = waipuid; // waipu[id]
     XBMC->Log(LOG_DEBUG, "[channel] waipuid: %s;", waipu_channel.waipuID.c_str());
 
-    int orderindex = channel["orderIndex"].GetUint() + 1;
-    waipu_channel.iUniqueId = orderindex; //waipu[orderIndex]
-    XBMC->Log(LOG_DEBUG, "[channel] id: %i;", orderindex);
+    int uniqueId = Utils::GetChannelId(waipuid.c_str());
+    waipu_channel.iUniqueId = uniqueId;
+    XBMC->Log(LOG_DEBUG, "[channel] id: %i;", uniqueId);
 
     string displayName = channel["displayName"].GetString();
     waipu_channel.strChannelName = displayName; //waipu[displayName]

--- a/src/WaipuData.h
+++ b/src/WaipuData.h
@@ -51,7 +51,7 @@ struct WaipuApiToken
 
 struct WaipuChannel
 {
-  int iUniqueId; //waipu[orderIndex]
+  int iUniqueId;
   string waipuID; // waipu[id]
   int iChannelNumber; //position
   string strChannelName; //waipu[displayName]


### PR DESCRIPTION
Up to now, we used waipus orderIndex as a unique channel id. But it seems that this orderIndex is unstable and thus the channels are mapped incorrectly from time to time.

Waipu uses a channel short string as unique id. This PR calculats a unqiue integer from thus id, the same way as implemented in pvr.zattoo.

It should fix broken epg, wrong channel logos, ...