### PR TITLE
Fix translation IDs and translate error messages

### DIFF
--- a/pvr.waipu/resources/language/resource.language.de_de/strings.po
+++ b/pvr.waipu/resources/language/resource.language.de_de/strings.po
@@ -10,46 +10,54 @@ msgstr ""
 "Language: de_DE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "#37201"
+msgctxt "#30001"
 msgid "General"
 msgstr "Allgemein"
 
-msgctxt "#37202"
+msgctxt "#30002"
 msgid "Mail"
 msgstr "E-Mail"
 
-msgctxt "#37203"
+msgctxt "#30003"
 msgid "Password"
 msgstr "Passwort"
 
-msgctxt "#37204"
+msgctxt "#30004"
 msgid "Protocol"
 msgstr "Protokoll"
 
-msgctxt "#37205"
+msgctxt "#30005"
 msgid "Misc"
 msgstr "Sonstiges"
 
-msgctxt "#37206"
+msgctxt "#30006"
 msgid "Check requirements"
 msgstr "Überprüfe Anforderungen"
 
-msgctxt "#37207"
+msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
 msgstr "Widevine CDM Bibliothek (erneut) installieren..."
 
-msgctxt "#37208"
+msgctxt "#30008"
 msgid "Provider"
 msgstr "Anbieter"
 
-msgctxt "#37209"
+msgctxt "#30009"
 msgid "Waipu.tv"
 msgstr "Waipu.tv"
 
-msgctxt "#37210"
+msgctxt "#30010"
 msgid "O2 TV"
 msgstr "O2 TV (beta)"
 
-msgctxt "#37230"
+msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
 msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+
+msgctxt "#30031"
+msgid "No network connection"
+msgstr "Keine Netzwerkverbindung"
+
+msgctxt "#30032"
+msgid "Invalid login credentials"
+msgstr "Ungültige Zugangsdaten"

--- a/pvr.waipu/resources/language/resource.language.en_gb/strings.po
+++ b/pvr.waipu/resources/language/resource.language.en_gb/strings.po
@@ -10,46 +10,54 @@ msgstr ""
 "Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-msgctxt "#37201"
+msgctxt "#30001"
 msgid "General"
 msgstr ""
 
-msgctxt "#37202"
+msgctxt "#30002"
 msgid "Mail"
 msgstr ""
 
-msgctxt "#37203"
+msgctxt "#30003"
 msgid "Password"
 msgstr ""
 
-msgctxt "#37204"
+msgctxt "#30004"
 msgid "Protocol"
 msgstr ""
 
-msgctxt "#37205"
+msgctxt "#30005"
 msgid "Misc"
 msgstr ""
 
-msgctxt "#37206"
+msgctxt "#30006"
 msgid "Check requirements"
 msgstr ""
 
-msgctxt "#37207"
+msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
 msgstr ""
 
-msgctxt "#37208"
+msgctxt "#30008"
 msgid "Provider"
 msgstr ""
 
-msgctxt "#37209"
+msgctxt "#30009"
 msgid "Waipu.tv"
 msgstr ""
 
-msgctxt "#37210"
+msgctxt "#30010"
 msgid "O2 TV (beta)"
 msgstr ""
 
-msgctxt "#37230"
+msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
+msgstr ""
+
+msgctxt "#30031"
+msgid "No network connection"
+msgstr ""
+
+msgctxt "#30032"
+msgid "Invalid login credentials"
 msgstr ""

--- a/pvr.waipu/resources/settings.xml
+++ b/pvr.waipu/resources/settings.xml
@@ -1,14 +1,14 @@
 <?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <settings>
-    <category label="37201">
-		<setting id="username" type="text" label="37202" default="" />
-		<setting id="password" type="text" option="hidden" label="37203" default="" />
-		<setting id="provider_select" label="37208" type="enum" lvalues="37209|37210" default="0" />
+    <category label="30001">
+		<setting id="username" type="text" label="30002" default="" />
+		<setting id="password" type="text" option="hidden" label="30003" default="" />
+		<setting id="provider_select" label="30008" type="enum" lvalues="30009|30010" default="0" />
 		<setting type="sep"/>
-		<setting id="install_widevine" type="action" label="37207" action="RunScript(script.module.inputstreamhelper, widevine_install)" visible="!system.platform.android"/>
-		<setting id="run_check" type="action" label="37206" action="RunScript(special://xbmc/addons/pvr.waipu/resources/check_requirements.py)" />
+		<setting id="install_widevine" type="action" label="30007" action="RunScript(script.module.inputstreamhelper, widevine_install)" visible="!system.platform.android"/>
+		<setting id="run_check" type="action" label="30006" action="RunScript(special://xbmc/addons/pvr.waipu/resources/check_requirements.py)" />
 		</category>
-	<category label="37205">
-		<setting id="protocol" type="labelenum" label="37204" values="MPEG_DASH|HLS" default="MPEG_DASH" />
+	<category label="30005">
+		<setting id="protocol" type="labelenum" label="30004" values="MPEG_DASH|HLS" default="MPEG_DASH" />
 	</category>
 </settings>

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -130,12 +130,12 @@ extern "C"
       case WAIPU_LOGIN_STATUS_NO_NETWORK:
         m_CurStatus = ADDON_STATUS_NEED_RESTART;
         XBMC->Log(LOG_ERROR, "[load data] Network issue");
-        XBMC->QueueNotification(QUEUE_ERROR, "No network connection");
+        XBMC->QueueNotification(QUEUE_ERROR, XBMC->GetLocalizedString(30031));
         break;
       case WAIPU_LOGIN_STATUS_INVALID_CREDENTIALS:
         m_CurStatus = ADDON_STATUS_NEED_SETTINGS;
         XBMC->Log(LOG_ERROR, "[load data] Login invalid");
-        XBMC->QueueNotification(QUEUE_ERROR, "Invalid login credentials");
+        XBMC->QueueNotification(QUEUE_ERROR, XBMC->GetLocalizedString(30032));
         break;
       case WAIPU_LOGIN_STATUS_UNKNOWN:
         XBMC->Log(LOG_ERROR, "[login status] unknown state");


### PR DESCRIPTION
Change translation IDs to range:
- strings 30000 thru 30999 reserved for plugins and plugin settings

Translate two error mesage: invalid credentials / no network connection