### PR TITLE
Show record option only if available for program/channel

### DIFF
--- a/src/WaipuData.h
+++ b/src/WaipuData.h
@@ -65,11 +65,11 @@ struct WaipuChannelGroup
   std::vector<WaipuChannel> channels;
 };
 
-struct WaipuEPGMappingEntry
+struct WaipuEPGEntry
 {
-  int iBroadcastId;
+  int iUniqueBroadcastId;
   int iUniqueChannelId;
-  std::string waipuId;
+  bool isRecordable;
 };
 
 class WaipuData
@@ -101,6 +101,7 @@ public:
 
   std::string GetLicense(void);
   WAIPU_LOGIN_STATUS GetLoginStatus(void);
+  PVR_ERROR IsEPGTagRecordable(const EPG_TAG* tag, bool* bIsRecordable);
 
 protected:
   string HttpGet(const string& url);
@@ -117,6 +118,7 @@ protected:
 private:
   bool ParseAccessToken(void);
   std::vector<WaipuChannel> m_channels;
+  std::vector<WaipuEPGEntry> m_epgEntries;
   std::vector<WaipuChannelGroup> m_channelGroups;
   std::string username;
   std::string password;

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -541,7 +541,15 @@ extern "C"
   PVR_ERROR SetRecordingLifetime(const PVR_RECORDING*) { return PVR_ERROR_NOT_IMPLEMENTED; }
   PVR_ERROR GetStreamProperties(PVR_STREAM_PROPERTIES*) { return PVR_ERROR_NOT_IMPLEMENTED; }
   PVR_ERROR GetStreamTimes(PVR_STREAM_TIMES*) { return PVR_ERROR_NOT_IMPLEMENTED; }
-  PVR_ERROR IsEPGTagRecordable(const EPG_TAG*, bool*) { return PVR_ERROR_NOT_IMPLEMENTED; }
+  PVR_ERROR IsEPGTagRecordable(const EPG_TAG* tag, bool* bIsRecordable)
+  {
+    if (m_data)
+    {
+      return m_data->IsEPGTagRecordable(tag, bIsRecordable);
+    }
+
+    return PVR_ERROR_FAILED;
+  }
   PVR_ERROR GetEPGTagEdl(const EPG_TAG* epgTag, PVR_EDL_ENTRY edl[], int* size)
   {
     return PVR_ERROR_NOT_IMPLEMENTED;


### PR DESCRIPTION
Currently, all epg entries show a record button. However, not every channel/program is recordable. This PR passes information if a program is recordable to kodi.
As a consequence, record button appears only if backend supports it.