### PR TITLE
Fix: prevent recording of epg tags in the past

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.3.2"
+  version="1.3.3"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -30,6 +30,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.3.3 Fix: hide recordable option for items in the past 
 - 1.3.2 Add inputstream.adaptive to dependencies; Fix translation IDs; Show record option only if available
 - 1.3.1 Add channel groups: display favorites
 - 1.3.0 Implement O2 authentication

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -1139,6 +1139,14 @@ std::string WaipuData::GetLicense(void)
 
 PVR_ERROR WaipuData::IsEPGTagRecordable(const EPG_TAG* tag, bool* bIsRecordable)
 {
+  time_t current_time;
+  time(&current_time);
+  if (tag->endTime < current_time)
+  {
+    // if tag is in past, no recording is possible
+    *bIsRecordable = false;
+    return PVR_ERROR_NO_ERROR;
+  }
 
   for (const auto& epgEntry : m_epgEntries)
   {


### PR DESCRIPTION
If an EPG tag is in the past, it should not be possible to record it.

This PR removes the record option for EPG tags that are in the past. If a show is running, it should still be possible to record it.