### PR TITLE
Feature: Implement VoD Channels

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.3.3"
+  version="1.4.0"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -30,6 +30,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.4.0 Implement Video on Demand channels
 - 1.3.3 Fix: hide recordable option for items in the past 
 - 1.3.2 Add inputstream.adaptive to dependencies; Fix translation IDs; Show record option only if available
 - 1.3.1 Add channel groups: display favorites

--- a/src/WaipuData.h
+++ b/src/WaipuData.h
@@ -57,6 +57,7 @@ struct WaipuChannel
   string strChannelName; //waipu[displayName]
   string strIconPath; // waipu[links][rel=iconlargehd]
   string strStreamURL; // waipu[links][rel=livePlayout]
+  bool tvfuse; // tvfuse is on demand channel
 };
 
 struct WaipuChannelGroup
@@ -70,6 +71,7 @@ struct WaipuEPGEntry
   int iUniqueBroadcastId;
   int iUniqueChannelId;
   bool isRecordable;
+  string streamUrlProvider;
 };
 
 class WaipuData
@@ -92,6 +94,7 @@ public:
   int GetRecordingsAmount(bool bDeleted);
   PVR_ERROR GetRecordings(ADDON_HANDLE handle, bool bDeleted);
   std::string GetRecordingURL(const PVR_RECORDING& recording, const string& protocol);
+  std::string GetEPGTagURL(const EPG_TAG& tag, const string& protocol);
   PVR_ERROR DeleteRecording(const PVR_RECORDING& recording);
 
   int GetTimersAmount(void);
@@ -102,6 +105,7 @@ public:
   std::string GetLicense(void);
   WAIPU_LOGIN_STATUS GetLoginStatus(void);
   PVR_ERROR IsEPGTagRecordable(const EPG_TAG* tag, bool* bIsRecordable);
+  PVR_ERROR IsEPGTagPlayable(const EPG_TAG* tag, bool* bIsPlayable);
 
 protected:
   string HttpGet(const string& url);

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -263,13 +263,14 @@ extern "C"
     return PVR_ERROR_SERVER_ERROR;
   }
 
-  PVR_ERROR IsEPGTagPlayable(const EPG_TAG*, bool* bIsPlayable)
+  PVR_ERROR IsEPGTagPlayable(const EPG_TAG* tag, bool* bIsPlayable)
   {
-    /**
-  *bIsPlayable = true;
-  return PVR_ERROR_NO_ERROR;
-  **/
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    if (m_data)
+    {
+      return m_data->IsEPGTagPlayable(tag, bIsPlayable);
+    }
+
+    return PVR_ERROR_FAILED;
   }
 
   int GetChannelsAmount(void)
@@ -482,8 +483,20 @@ extern "C"
                                       PVR_NAMED_VALUE* properties,
                                       unsigned int* iPropertiesCount)
   {
-    return PVR_ERROR_NOT_IMPLEMENTED;
+    XBMC->Log(LOG_DEBUG, "[EPG TAG] play it...");
+
+    string strUrl = m_data->GetEPGTagURL(*tag, protocol);
+    if (strUrl.empty())
+    {
+      return PVR_ERROR_FAILED;
+    }
+    *iPropertiesCount = 0;
+    setStreamProperties(properties, iPropertiesCount, strUrl);
+    setStreamProperty(properties, iPropertiesCount, PVR_STREAM_PROPERTY_ISREALTIMESTREAM, "true");
+
+    return PVR_ERROR_NO_ERROR;
   }
+
   PVR_ERROR CallMenuHook(const PVR_MENUHOOK& menuhook, const PVR_MENUHOOK_DATA&)
   {
     return PVR_ERROR_NOT_IMPLEMENTED;


### PR DESCRIPTION
This PR implements Video on Demand (VoD).

Waipu provides this feature for some channels. In EPG a green circle is added to episodes that can be played from a VoD channel:
![1579552364_grim](https://user-images.githubusercontent.com/4031504/72756146-a8d32b00-3bcc-11ea-8513-b1f8d294a3f4.png)

In the next step, it is possible to play the selected episode/movie by selecting "Sendung ansehen":
![1579552369_grim](https://user-images.githubusercontent.com/4031504/72756143-a8d32b00-3bcc-11ea-83b4-1e278ffd1d42.png)




