### PR TITLE
Migrate settings to new format

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.4.0"
+  version="1.4.1"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -30,6 +30,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.4.1 New settings format; add external dependencies
 - 1.4.0 Implement Video on Demand channels
 - 1.3.3 Fix: hide recordable option for items in the past 
 - 1.3.2 Add inputstream.adaptive to dependencies; Fix translation IDs; Show record option only if available

--- a/pvr.waipu/resources/settings.xml
+++ b/pvr.waipu/resources/settings.xml
@@ -1,14 +1,87 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes"?>
-<settings>
-    <category label="30001">
-		<setting id="username" type="text" label="30002" default="" />
-		<setting id="password" type="text" option="hidden" label="30003" default="" />
-		<setting id="provider_select" label="30008" type="enum" lvalues="30009|30010" default="0" />
-		<setting type="sep"/>
-		<setting id="install_widevine" type="action" label="30007" action="RunScript(script.module.inputstreamhelper, widevine_install)" visible="!system.platform.android"/>
-		<setting id="run_check" type="action" label="30006" action="RunScript(special://xbmc/addons/pvr.waipu/resources/check_requirements.py)" />
+<?xml version="1.0" ?>
+<settings version="1">
+	<section id="pvr.waipu">
+		<category id="credentials" label="30001" help="">
+			<group id="1" label="">
+				<setting id="username" type="string" label="30002" help="">
+					<level>0</level>
+					<default />
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<control type="edit" format="string">
+						<heading>30002</heading>
+					</control>
+				</setting>
+				<setting id="password" type="string" label="30003" help="">
+					<level>0</level>
+					<default />
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<control type="edit" format="string">
+						<heading>30003</heading>
+						<hidden>true</hidden>
+					</control>
+				</setting>
+				<setting id="provider_select" type="integer" label="30008"
+					help="">
+					<level>0</level>
+					<default>0</default>
+					<constraints>
+						<options>
+							<option label="30009">0</option>
+							<option label="30010">1</option>
+						</options>
+					</constraints>
+					<control type="spinner" format="string" />
+				</setting>
+			</group>
+			<group id="2" label="">
+				<setting id="install_widevine" type="string" label="30007"
+					help="">
+					<level>0</level>
+					<default />
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<control type="button" format="action">
+						<data>RunScript(script.module.inputstreamhelper,widevine_install)
+						</data>
+					</control>
+					<dependency type="visible" operator="!is"
+						setting="system.platform.android">true</dependency>
+				</setting>
+				<setting id="run_check" type="string" label="30006" help="">
+					<level>0</level>
+					<default />
+					<constraints>
+						<allowempty>true</allowempty>
+					</constraints>
+					<control type="button" format="action">
+						<data>RunScript(special://xbmc/addons/pvr.waipu/resources/check_requirements.py)
+						</data>
+					</control>
+					<dependency type="visible" operator="!is"
+						setting="system.platform.android">true</dependency>
+				</setting>
+			</group>
 		</category>
-	<category label="30005">
-		<setting id="protocol" type="labelenum" label="30004" values="MPEG_DASH|HLS" default="MPEG_DASH" />
-	</category>
+		<category id="misc" label="30005" help="">
+			<group id="3" label="">
+				<setting id="protocol" type="string" label="30004" help="">
+					<level>2</level>
+					<default>MPEG_DASH</default>
+					<constraints>
+						<options sort="ascending">
+							<option label="MPEG_DASH">MPEG_DASH</option>
+							<option label="HLS">HLS</option>
+						</options>
+						<allowempty>false</allowempty>
+					</constraints>
+					<control type="spinner" format="string" />
+				</setting>
+			</group>
+		</category>
+	</section>
 </settings>


### PR DESCRIPTION
Convert settings to new format. See [here](https://kodi.wiki/view/Add-on_settings_conversion).

Runtime tested locally, seems to work as expected. The setting protocol selection was changed to level `2 - Advanced`.

I am not sure if the dependency that hides settings on Android is set correctly. Should be reviewed...