### PR TITLE
[Matrix] API change update / cleanups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,6 @@ obj-x86_64-linux-gnu/
 # KDevelop 4
 *.kdev4
 
-# Visual Studio
-.vs/
-
 # gedit
 *~
 
@@ -37,3 +34,17 @@ obj-x86_64-linux-gnu/
 
 # clion
 .idea/
+
+# to prevent add after a "git format-patch VALUE" and "git add ." call
+/*.patch
+
+# Visual Studio Code
+.vscode
+
+# to prevent add if project code opened by Visual Studio over CMake file
+.vs/
+
+# General MacOS
+.DS_Store
+.AppleDouble
+.LSOverride

--- a/README.md
+++ b/README.md
@@ -41,5 +41,5 @@ For any support regarding this plugin, please create a github issue.
 
 ## Useful links
 
-* [Kodi's PVR user support](http://forum.kodi.tv/forumdisplay.php?fid=167)
-* [Kodi's PVR development support](http://forum.kodi.tv/forumdisplay.php?fid=136)
+* [Kodi's PVR user support](https://forum.kodi.tv/forumdisplay.php?fid=167)
+* [Kodi's PVR development support](https://forum.kodi.tv/forumdisplay.php?fid=136)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
-[![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](pvr.waipu/LICENSE.txt) [![Build Status](https://travis-ci.org/flubshi/pvr.waipu.svg?branch=Matrix)](https://travis-ci.org/flubshi/pvr.waipu) [![Build status](https://ci.appveyor.com/api/projects/status/mak70bfs0bj78y53/branch/Matrix?svg=true)](https://ci.appveyor.com/project/flubshi/pvr-waipu/branch/Matrix) [![Build Status](https://jenkins.kodi.tv/buildStatus/icon?job=flubshi%2Fpvr.waipu%2FMatrix)](https://jenkins.kodi.tv/job/flubshi/job/pvr.waipu/job/Matrix/)
+[![License: GPL v2](https://img.shields.io/badge/License-GPL%20v2-blue.svg)](pvr.waipu/LICENSE.txt)
+[![Build Status](https://travis-ci.org/flubshi/pvr.waipu.svg?branch=Matrix)](https://travis-ci.org/flubshi/pvr.waipu)
+[![Build status](https://ci.appveyor.com/api/projects/status/mak70bfs0bj78y53/branch/Matrix?svg=true)](https://ci.appveyor.com/project/flubshi/pvr-waipu/branch/Matrix)
+[![Build Status](https://jenkins.kodi.tv/buildStatus/icon?job=flubshi%2Fpvr.waipu%2FMatrix)](https://jenkins.kodi.tv/job/flubshi/job/pvr.waipu/job/Matrix/)
 
 # waipu PVR
 waipu PVR client addon for [Kodi](https://kodi.tv)

--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.4.3"
+  version="1.4.4"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -30,6 +30,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.4.4 Update PVR API 6.4.0; minor cleanups
 - 1.4.3 Update PVR API 6.3.0
 - 1.4.2 Update PVR API 6.2.0
 - 1.4.1 New settings format; add external dependencies

--- a/src/client.cpp
+++ b/src/client.cpp
@@ -309,7 +309,7 @@ extern "C"
   {
     setStreamProperty(properties, propertiesCount, PVR_STREAM_PROPERTY_STREAMURL, url);
     XBMC->Log(LOG_DEBUG, "[PLAY STREAM] url: %s", url.c_str());
-    setStreamProperty(properties, propertiesCount, PVR_STREAM_PROPERTY_INPUTSTREAMADDON,
+    setStreamProperty(properties, propertiesCount, PVR_STREAM_PROPERTY_INPUTSTREAM,
                       "inputstream.adaptive");
 
     if (protocol == "MPEG_DASH")


### PR DESCRIPTION
Related to xbmc/xbmc#17586 and to bring in after them.

Commit 1:
--------------
Seen you added the status badges in one line where it makes very long.
This add linebreaks inside, as this it is also shown by Markdown in one line.

Commit 2:
--------------
Only set two http to https.

Commit 3:
----------------
To have them equal with other addons and prevent some Windows and Mac parts.

Commit 4:
----------------
Thought to make this to request on Kodi:
https://github.com/xbmc/xbmc/commit/a6aac07fd16f8f20389e760ddc26c5949af77f33
and remove this deprecated part.

Can you also do a test, it should normally work, but to make sure.
