### PR TITLE
Fix crash if no preview images available

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="1.5.0"
+  version="1.5.1"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -30,6 +30,7 @@
     <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
   </assets>
   <news>
+- 1.5.1 Fix crash if no preview image available for recording
 - 1.5.0 Update PVR API 6.5.1; Update Global API 1.2.0
 - 1.4.7 Show HD channel logos; Remove 'check requirements' script 
 - 1.4.6 Update PVR API 6.5.0

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -879,9 +879,11 @@ PVR_ERROR WaipuData::GetRecordings(ADDON_HANDLE handle, bool bDeleted)
     // set folder; test
     strncpy(tag.strDirectory, rec_title.c_str(), sizeof(tag.strTitle) - 1);
 
-    // set image
-    if (epgData.HasMember("previewImages") && epgData["previewImages"].IsArray())
-    {
+      // set image
+      if (epgData.HasMember ("previewImages")
+	  && epgData["previewImages"].IsArray ()
+	  && epgData["previewImages"].Size () > 0)
+	{
       string rec_img = epgData["previewImages"][0].GetString();
       rec_img = rec_img + "?width=256&height=256";
       strncpy(tag.strIconPath, rec_img.c_str(), sizeof(tag.strIconPath) - 1);


### PR DESCRIPTION
Fixes crash if no preview image available for recording.

Reported here:
https://www.kodinerds.net/index.php/Thread/64613-Release-PVR-Plugin-Waipu-tv-f%C3%BCr-Kodi-19/?postID=591120#post591120