### PR TITLE
Authentication: enabled refresh token grant type

### DIFF
--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -162,7 +162,7 @@ bool WaipuData::WaipuLogin()
   time(&currTime);
   kodi::Log(ADDON_LOG_DEBUG, "[token] current time %i", currTime);
   kodi::Log(ADDON_LOG_DEBUG, "[token] expire  time %i", m_apiToken.expires);
-  if (!m_apiToken.accessToken.empty() && (m_apiToken.expires - 10 * 60) > currTime)
+  if (!m_apiToken.accessToken.empty() && (m_apiToken.expires - 20 * 60) > currTime)
   {
     // API token exists and is valid, more than x in future
     kodi::Log(ADDON_LOG_DEBUG, "[login check] old token still valid");
@@ -170,13 +170,13 @@ bool WaipuData::WaipuLogin()
   }
 
   ostringstream dataStream;
-  if (m_apiToken.expires < currTime && false)
+  if (!m_apiToken.refreshToken.empty())
   {
+    // Since the refresh token is valid for a long time, we do not check expiration for now
     // refresh API token
     dataStream << "refresh_token=" << Utils::UrlEncode(m_apiToken.refreshToken)
                << "&grant_type=refresh_token";
-    kodi::Log(ADDON_LOG_DEBUG, "[login check] Login-Request (refresh): %s;",
-              dataStream.str().c_str());
+    kodi::Log(ADDON_LOG_DEBUG, "[login check] Login-Request (refresh): %s;", dataStream.str().c_str());
   }
   else
   {


### PR DESCRIPTION
This prevents frequent login attempt using login credentials. Instead, the refresh token is used to retrieve a new access token.