### PR TITLE
Retrieve EPG tag on playback instead using local cached url.

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="2.8.0"
+  version="2.8.1"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
       <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
     </assets>
     <news>
+- 2.8.1 Fix EPG tag playback
 - 2.8.0 Add EPG eit categories (color EPG)
 - 2.7.0 Add DASH/HLS autoselect feature
 - 2.6.1 Fix infinite login lock
@@ -36,7 +37,6 @@
 - 2.5.1 Update addon depends versions and remove script.module.requests
 - 2.5.0 Update PVR API 7.1.0
 - 2.4.0 Implement replay feature (thanks to quthla); improve recording/timer handling
-- 2.3.0 Improve login and authentication; allow user to select HLS/DASH streams
     </news>
   </extension>
 </addon>

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -129,6 +129,16 @@ time_t Utils::StringToTime(std::string timeString)
   return ret;
 }
 
+
+std::string Utils::TimeToString(const time_t time)
+{
+  char time_str[100];
+  std::tm* pstm = std::localtime(&time);
+  // 2019-01-20T23:59:59
+  std::strftime(time_str, 32, "%Y-%m-%dT%H:%M:%S", pstm);
+  return time_str;
+}
+
 std::string Utils::ltrim(std::string str, const std::string chars)
 {
   str.erase(0, str.find_first_not_of(chars));

--- a/src/Utils.h
+++ b/src/Utils.h
@@ -22,6 +22,7 @@ public:
                                               const char& delim,
                                               int maxParts = 0);
   static time_t StringToTime(std::string timeString);
+  static std::string TimeToString(time_t time);
   static std::string ltrim(std::string str, const std::string chars = "\t\n\v\f\r _");
   static std::string rtrim(std::string str, const std::string chars = "\t\n\v\f\r ");
   static int GetIDDirty(std::string str);


### PR DESCRIPTION
Fixes broken playback when Kodi is restarted and EPG tag is not in cache.