### PR TITLE
Fix instant replay; store replay/record option in EPG tag flag

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="2.8.1"
+  version="2.8.2"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -29,6 +29,7 @@
       <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
     </assets>
     <news>
+- 2.8.2 Fix replay and recordable state
 - 2.8.1 Fix EPG tag playback
 - 2.8.0 Add EPG eit categories (color EPG)
 - 2.7.0 Add DASH/HLS autoselect feature
@@ -36,7 +37,6 @@
 - 2.6.0 Implement DeviceCapabilities API; Allow resolution by addon settings
 - 2.5.1 Update addon depends versions and remove script.module.requests
 - 2.5.0 Update PVR API 7.1.0
-- 2.4.0 Implement replay feature (thanks to quthla); improve recording/timer handling
     </news>
   </extension>
 </addon>

--- a/src/WaipuData.h
+++ b/src/WaipuData.h
@@ -49,6 +49,9 @@ enum class WAIPU_LOGIN_STATUS
   UNKNOWN
 };
 
+static const unsigned int EPG_TAG_FLAG_IS_RECORDABLE = (1 << 28);
+static const unsigned int EPG_TAG_FLAG_INSTANT_RESTART_ALLOWED = (1 << 29);
+
 class ATTRIBUTE_HIDDEN WaipuData : public kodi::addon::CAddonBase,
                                    public kodi::addon::CInstancePVRClient
 {
@@ -133,15 +136,6 @@ private:
     std::vector<WaipuChannel> channels;
   };
 
-  struct WaipuEPGEntry
-  {
-    int iUniqueBroadcastId;
-    int iUniqueChannelId;
-    bool isRecordable;
-    bool instantRestartAllowed;
-    std::string streamUrlProvider;
-  };
-
   std::string m_username;
   std::string m_password;
   std::string m_userhandle = "";
@@ -149,7 +143,6 @@ private:
   WAIPU_PROVIDER m_provider;
 
   std::vector<WaipuChannel> m_channels;
-  std::vector<WaipuEPGEntry> m_epgEntries;
   std::vector<WaipuChannelGroup> m_channelGroups;
 
   WaipuApiToken m_apiToken;


### PR DESCRIPTION
Before, we saved the recordable / instant replay state in a local variable when retrieving the epg data. If Kodi is restarted but EPG is cached, the tags are not retrieved again. In this case, Kodi thinks a tag is not recordable/replayable.

Now, we store the state in EPG tag flag (not best practice, because flag is not defined). Maybe we will find a better solution in the future...