### PR TITLE
[Matrix] release change to use as major same as Kodi, here 19.0.0 / translation sync with Nexus

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,14 +27,14 @@ jobs:
       env:
         DEBIAN_BUILD: ${{ matrix.DEBIAN_BUILD }}
       run: |
-        if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/xbmc-nightly; fi
+        if [[ $DEBIAN_BUILD == true ]]; then sudo add-apt-repository -y ppa:team-xbmc/ppa; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get update; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get install fakeroot; fi
     - name: Checkout Kodi repo
       uses: actions/checkout@v2
       with:
         repository: xbmc/xbmc
-        ref: master
+        ref: Matrix
         path: xbmc
     - name: Checkout pvr.waipu repo
       uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
       run: |
         if [[ $DEBIAN_BUILD != true ]]; then cd ${app_id} && mkdir -p build && cd build; fi
         if [[ $DEBIAN_BUILD != true ]]; then cmake -DADDONS_TO_BUILD=${app_id} -DADDON_SRC_PREFIX=${{ github.workspace }} -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=${{ github.workspace }}/xbmc/addons -DPACKAGE_ZIP=1 ${{ github.workspace }}/xbmc/cmake/addons; fi
-        if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/master/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
+        if [[ $DEBIAN_BUILD == true ]]; then wget https://raw.githubusercontent.com/xbmc/xbmc/Matrix/xbmc/addons/kodi-dev-kit/tools/debian-addon-package-test.sh && chmod +x ./debian-addon-package-test.sh; fi
         if [[ $DEBIAN_BUILD == true ]]; then sudo apt-get build-dep ${{ github.workspace }}/${app_id}; fi
     - name: Build
       env:

--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="2.9.4"
+  version="19.0.0"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -25,6 +25,16 @@
       <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
     </assets>
     <news>
+- 19.0.0
+  - Translations updates from Weblate
+    - ko_kr
+    - Changed to allow also addon.xml content update by Weblate
+  - Cleanup and improve Debian packaging
+  - Minor cleanup on addon.xml (change en_US to en_GB)
+  - Changed test builds to 'Kodi 19 Matrix'
+  - Increased version to 19.0.0
+    - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+      This done to know easier to which Kodi the addon works.
 - 2.9.4 Set PVR Addon User-Agent
 - 2.9.3 Release bump
 - 2.9.2 Improve internal login handling

--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -12,10 +12,6 @@
     point="kodi.pvrclient"
     library_@PLATFORM@="@LIBRARY_FILENAME@"/>
   <extension point="xbmc.addon.metadata">
-    <summary lang="de_DE">waipu.tv PVR Client</summary>
-    <summary lang="en_GB">waipu.tv PVR Client</summary>
-    <description lang="de_DE">waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt.</description>
-    <description lang="en_GB">waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers.</description>
     <platform>@PLATFORM@</platform>
     <license>GNU General Public License. Version 2, June 1991</license>
     <forum></forum>
@@ -40,5 +36,9 @@
 - 2.8.1 Fix EPG tag playback
 - 2.8.0 Add EPG eit categories (color EPG)
     </news>
+    <summary lang="de_DE">waipu.tv PVR Client</summary>
+    <summary lang="en_GB">waipu.tv PVR Client</summary>
+    <description lang="de_DE">waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt.</description>
+    <description lang="en_GB">waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers.</description>
   </extension>
 </addon>

--- a/pvr.waipu/resources/language/resource.language.af_za/strings.po
+++ b/pvr.waipu/resources/language/resource.language.af_za/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: af_za\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.am_et/strings.po
+++ b/pvr.waipu/resources/language/resource.language.am_et/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: am_et\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ar_sa/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ar_sa/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: ar_sa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.az_az/strings.po
+++ b/pvr.waipu/resources/language/resource.language.az_az/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: az_az\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.be_by/strings.po
+++ b/pvr.waipu/resources/language/resource.language.be_by/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: be_by\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.bg_bg/strings.po
+++ b/pvr.waipu/resources/language/resource.language.bg_bg/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: bg_bg\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.bs_ba/strings.po
+++ b/pvr.waipu/resources/language/resource.language.bs_ba/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: bs_ba\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ca_es/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ca_es/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: ca_es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.cs_cz/strings.po
+++ b/pvr.waipu/resources/language/resource.language.cs_cz/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: cs_cz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.cy_gb/strings.po
+++ b/pvr.waipu/resources/language/resource.language.cy_gb/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: cy_gb\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=6; plural=(n==0) ? 0 : (n==1) ? 1 : (n==2) ? 2 : (n==3) ? 3 :(n==6) ? 4 : 5;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.da_dk/strings.po
+++ b/pvr.waipu/resources/language/resource.language.da_dk/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: da_dk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.el_gr/strings.po
+++ b/pvr.waipu/resources/language/resource.language.el_gr/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: el_gr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.en_au/strings.po
+++ b/pvr.waipu/resources/language/resource.language.en_au/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: en_au\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.en_nz/strings.po
+++ b/pvr.waipu/resources/language/resource.language.en_nz/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: en_nz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.en_us/strings.po
+++ b/pvr.waipu/resources/language/resource.language.en_us/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: en_us\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.eo/strings.po
+++ b/pvr.waipu/resources/language/resource.language.eo/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: eo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.es_ar/strings.po
+++ b/pvr.waipu/resources/language/resource.language.es_ar/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: es_ar\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.es_es/strings.po
+++ b/pvr.waipu/resources/language/resource.language.es_es/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: es_es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.es_mx/strings.po
+++ b/pvr.waipu/resources/language/resource.language.es_mx/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: es_mx\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.et_ee/strings.po
+++ b/pvr.waipu/resources/language/resource.language.et_ee/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: et_ee\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.eu_es/strings.po
+++ b/pvr.waipu/resources/language/resource.language.eu_es/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: eu_es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.fa_af/strings.po
+++ b/pvr.waipu/resources/language/resource.language.fa_af/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: fa_af\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.fa_ir/strings.po
+++ b/pvr.waipu/resources/language/resource.language.fa_ir/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: fa_ir\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.fi_fi/strings.po
+++ b/pvr.waipu/resources/language/resource.language.fi_fi/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: fi_fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.fo_fo/strings.po
+++ b/pvr.waipu/resources/language/resource.language.fo_fo/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: fo_fo\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.fr_ca/strings.po
+++ b/pvr.waipu/resources/language/resource.language.fr_ca/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: fr_ca\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.fr_fr/strings.po
+++ b/pvr.waipu/resources/language/resource.language.fr_fr/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: fr_fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.gl_es/strings.po
+++ b/pvr.waipu/resources/language/resource.language.gl_es/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: gl_es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.he_il/strings.po
+++ b/pvr.waipu/resources/language/resource.language.he_il/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: he_il\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=4; plural=(n == 1) ? 0 : ((n == 2) ? 1 : ((n > 10 && n % 10 == 0) ? 2 : 3));\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.hi_in/strings.po
+++ b/pvr.waipu/resources/language/resource.language.hi_in/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: hi_in\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.hr_hr/strings.po
+++ b/pvr.waipu/resources/language/resource.language.hr_hr/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: hr_hr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.hu_hu/strings.po
+++ b/pvr.waipu/resources/language/resource.language.hu_hu/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: hu_hu\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.hy_am/strings.po
+++ b/pvr.waipu/resources/language/resource.language.hy_am/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: hy_am\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.id_id/strings.po
+++ b/pvr.waipu/resources/language/resource.language.id_id/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: id_id\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.is_is/strings.po
+++ b/pvr.waipu/resources/language/resource.language.is_is/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: is_is\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.it_it/strings.po
+++ b/pvr.waipu/resources/language/resource.language.it_it/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: it_it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ja_jp/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ja_jp/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: ja_jp\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ko_kr/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ko_kr/strings.po
@@ -4,51 +4,56 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Report-Msgid-Bugs-To: translations@kodi.tv\n"
+"PO-Revision-Date: 2021-09-06 13:30+0000\n"
+"Last-Translator: Minho Park <parkmino@gmail.com>\n"
+"Language-Team: Korean <https://kodi.weblate.cloud/projects/kodi-add-ons-pvr-clients/pvr-waipu/ko_kr/>\n"
+"Language: ko_kr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+"X-Generator: Weblate 4.8\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr "일반"
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr "메일"
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr "비밀번호"
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr "프로토콜"
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr "스트리밍"
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr "InputStream 도우미 정보"
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr "Widevine CDM 라이브러리 (재)설치..."
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr "공급자"
 
 msgctxt "#30009"
 msgid "Waipu.tv"
@@ -56,19 +61,19 @@ msgstr "Waipu.tv"
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
-msgstr ""
+msgstr "O2 TV (베타)"
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr "스트리밍 프로토콜"
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr "비디오 해상도"
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr "오디오 코덱"
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
@@ -108,32 +113,28 @@ msgstr "AAC-LC: 128kBit, 48kHz"
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr "오류: 로그인할 수 없습니다. 자격 증명을 확인하십시오!"
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr "네트워크 연결 없음"
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr "잘못된 로그인 자격 증명"
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr "필수 사용자 이름과 비밀번호를 사용할 수 없음"
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr "토큰 새로 고침"
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr "기타"
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr "장치 ID"

--- a/pvr.waipu/resources/language/resource.language.lt_lt/strings.po
+++ b/pvr.waipu/resources/language/resource.language.lt_lt/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: lt_lt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 1 && (n % 100 < 11 || n % 100 > 19)) ? 0 : ((n % 10 >= 2 && n % 10 <= 9 && (n % 100 < 11 || n % 100 > 19)) ? 1 : 2);\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.lv_lv/strings.po
+++ b/pvr.waipu/resources/language/resource.language.lv_lv/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: lv_lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=(n % 10 == 0 || n % 100 >= 11 && n % 100 <= 19) ? 0 : ((n % 10 == 1 && n % 100 != 11) ? 1 : 2);\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.mi/strings.po
+++ b/pvr.waipu/resources/language/resource.language.mi/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: mi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.mk_mk/strings.po
+++ b/pvr.waipu/resources/language/resource.language.mk_mk/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: mk_mk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n==1 || n%10==1 ? 0 : 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ml_in/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ml_in/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: ml_in\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.mn_mn/strings.po
+++ b/pvr.waipu/resources/language/resource.language.mn_mn/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: mn_mn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ms_my/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ms_my/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: ms_my\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.mt_mt/strings.po
+++ b/pvr.waipu/resources/language/resource.language.mt_mt/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: mt_mt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=4; plural=n==1 ? 0 : n==0 || ( n%100>1 && n%100<11) ? 1 : (n%100>10 && n%100<20 ) ? 2 : 3;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.my_mm/strings.po
+++ b/pvr.waipu/resources/language/resource.language.my_mm/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: my_mm\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.nb_no/strings.po
+++ b/pvr.waipu/resources/language/resource.language.nb_no/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: nb_no\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.nl_nl/strings.po
+++ b/pvr.waipu/resources/language/resource.language.nl_nl/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: nl_nl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.pl_pl/strings.po
+++ b/pvr.waipu/resources/language/resource.language.pl_pl/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: pl_pl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.pt_br/strings.po
+++ b/pvr.waipu/resources/language/resource.language.pt_br/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: pt_br\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.pt_pt/strings.po
+++ b/pvr.waipu/resources/language/resource.language.pt_pt/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: pt_pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ro_ro/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ro_ro/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: ro_ro\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ru_ru/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ru_ru/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: ru_ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.si_lk/strings.po
+++ b/pvr.waipu/resources/language/resource.language.si_lk/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: si_lk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n > 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.sk_sk/strings.po
+++ b/pvr.waipu/resources/language/resource.language.sk_sk/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: sk_sk\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.sl_si/strings.po
+++ b/pvr.waipu/resources/language/resource.language.sl_si/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: sl_si\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=4; plural=n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.sq_al/strings.po
+++ b/pvr.waipu/resources/language/resource.language.sq_al/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: sq_al\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.sr_rs/strings.po
+++ b/pvr.waipu/resources/language/resource.language.sr_rs/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: sr_rs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.sr_rs@latin/strings.po
+++ b/pvr.waipu/resources/language/resource.language.sr_rs@latin/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: sr_Latn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.sv_se/strings.po
+++ b/pvr.waipu/resources/language/resource.language.sv_se/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: sv_se\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.szl/strings.po
+++ b/pvr.waipu/resources/language/resource.language.szl/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: szl\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.ta_in/strings.po
+++ b/pvr.waipu/resources/language/resource.language.ta_in/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: ta_in\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.te_in/strings.po
+++ b/pvr.waipu/resources/language/resource.language.te_in/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: te_in\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.tg_tj/strings.po
+++ b/pvr.waipu/resources/language/resource.language.tg_tj/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: tg_tj\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.th_th/strings.po
+++ b/pvr.waipu/resources/language/resource.language.th_th/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: th_th\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.tr_tr/strings.po
+++ b/pvr.waipu/resources/language/resource.language.tr_tr/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: tr_tr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.uk_ua/strings.po
+++ b/pvr.waipu/resources/language/resource.language.uk_ua/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: uk_ua\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.uz_uz/strings.po
+++ b/pvr.waipu/resources/language/resource.language.uz_uz/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: uz_uz\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.vi_vn/strings.po
+++ b/pvr.waipu/resources/language/resource.language.vi_vn/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: vi_vn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.zh_cn/strings.po
+++ b/pvr.waipu/resources/language/resource.language.zh_cn/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: zh_cn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""

--- a/pvr.waipu/resources/language/resource.language.zh_tw/strings.po
+++ b/pvr.waipu/resources/language/resource.language.zh_tw/strings.po
@@ -4,55 +4,55 @@
 # Addon Provider: flubshi
 msgid ""
 msgstr ""
-"Language: de_DE\n"
+"Language: zh_tw\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Plural-Forms: nplurals=2; plural=n != 1;\n"
 
 msgctxt "Addon Summary"
 msgid "waipu.tv PVR Client"
-msgstr "waipu.tv PVR Client"
+msgstr ""
 
 msgctxt "Addon Description"
 msgid "waipu.tv PVR Client. Note: This is not an official waipu plugin and not related to Exaring AG or waipu.tv. It was developed by volunteers."
-msgstr "waipu.tv PVR Client. Hinweis: Dies ist kein offizielles Waipu-Plugin und steht nicht in Verbindung zur Exaring AG oder zu waipu.tv. Es wurde von Freiwilligen entwickelt."
+msgstr ""
 
 msgctxt "#30001"
 msgid "General"
-msgstr "Allgemein"
+msgstr ""
 
 msgctxt "#30002"
 msgid "Mail"
-msgstr "E-Mail"
+msgstr ""
 
 msgctxt "#30003"
 msgid "Password"
-msgstr "Passwort"
+msgstr ""
 
 msgctxt "#30004"
 msgid "Protocol"
-msgstr "Protokoll"
+msgstr ""
 
 msgctxt "#30005"
 msgid "Streaming"
-msgstr "Streaming"
+msgstr ""
 
 msgctxt "#30006"
 msgid "InputStream Helper information"
-msgstr "InputStream Helper Informationen"
+msgstr ""
 
 msgctxt "#30007"
 msgid "(Re)install Widevine CDM library..."
-msgstr "Widevine CDM Bibliothek (erneut) installieren..."
+msgstr ""
 
 msgctxt "#30008"
 msgid "Provider"
-msgstr "Anbieter"
+msgstr ""
 
 msgctxt "#30009"
 msgid "Waipu.tv"
-msgstr "Waipu.tv"
+msgstr ""
 
 msgctxt "#30010"
 msgid "O2 TV (beta)"
@@ -60,80 +60,76 @@ msgstr ""
 
 msgctxt "#30011"
 msgid "Streaming Protocol"
-msgstr "Streaming Protokoll"
+msgstr ""
 
 msgctxt "#30012"
 msgid "Video Resolution"
-msgstr "Video Auflösung"
+msgstr ""
 
 msgctxt "#30013"
 msgid "Audio Codecs"
-msgstr "Audio Codecs"
+msgstr ""
 
 msgctxt "#30014"
 msgid "SD-PALp25: h264; 720x540; 25fps"
-msgstr "SD-PALp25: h264; 720x540; 25fps"
+msgstr ""
 
 msgctxt "#30015"
 msgid "SD-PALp50: h264; 720x540; 50fps"
-msgstr "SD-PALp50: h264; 720x540; 50fps"
+msgstr ""
 
 msgctxt "#30016"
 msgid "HD-720p25: h264; 1280x720; 25fps"
-msgstr "HD-720p25: h264; 1280x720; 25fps"
+msgstr ""
 
 msgctxt "#30017"
 msgid "HD-720p50: h264; 1280x720; 50fps"
-msgstr "HD-720p50: h264; 1280x720; 50fps"
+msgstr ""
 
 msgctxt "#30018"
 msgid "HD-1080p25: h264; 1920x1080; 25fps"
-msgstr "HD-1080p25: h264; 1920x1080; 25fps"
+msgstr ""
 
 msgctxt "#30019"
 msgid "HD-1080p50: h264; 1920x1080; 50fps"
-msgstr "HD-1080p50: h264; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30020"
 msgid "HEVC-1080p50: hevc; 1920x1080; 50fps"
-msgstr "HEVC-1080p50: hevc; 1920x1080; 50fps"
+msgstr ""
 
 msgctxt "#30021"
 msgid "HEVC-2160p50: hevc; 3840x2160; 50fps"
-msgstr "HEVC-2160p50: hevc; 3840x2160; 50fps"
+msgstr ""
 
 msgctxt "#30025"
 msgid "AAC-LC: 128kBit, 48kHz"
-msgstr "AAC-LC: 128kBit, 48kHz"
+msgstr ""
 
 msgctxt "#30030"
 msgid "Error: Login not possible. Check credentials!"
-msgstr "Fehler: Login nicht möglich. Ungültiger Account!"
+msgstr ""
 
 msgctxt "#30031"
 msgid "No network connection"
-msgstr "Keine Netzwerkverbindung"
+msgstr ""
 
 msgctxt "#30032"
 msgid "Invalid login credentials"
-msgstr "Ungültige Zugangsdaten"
+msgstr ""
 
 msgctxt "#30033"
 msgid "Required username and password not available"
-msgstr "Benötigter Benutzername mit Password nicht vorhanden"
+msgstr ""
 
 msgctxt "#30034"
 msgid "Refresh Token"
-msgstr "Refresh Token"
+msgstr ""
 
 msgctxt "#30035"
 msgid "Misc"
-msgstr "Misc"
+msgstr ""
 
 msgctxt "#30036"
 msgid "Device ID"
-msgstr "Device ID"
-
-#~ msgctxt "#30010"
-#~ msgid "O2 TV"
-#~ msgstr "O2 TV (beta)"
+msgstr ""


### PR DESCRIPTION
Correct on first commit where I wrongly given the master branch for test build
On second commit has taken the new added and updated language files from Kodi Nexus version

Version to 19.0.0 increased to have equal to Kodi and to see on which Version this addon works.