### PR TITLE
[Nexus] release change to use as major same as Kodi, here 20.0.0

### DIFF
--- a/.github/workflows/changelog-and-release.yml
+++ b/.github/workflows/changelog-and-release.yml
@@ -133,7 +133,7 @@ jobs:
         shell: bash
 
       # Create a release at {steps.required-variables.outputs.branch}
-      # - tag and release name format: {steps.required-variables.outputs.version}-{steps.required-variables.outputs.branch} ie. 1.0.0-Matrix
+      # - tag and release name format: {steps.required-variables.outputs.version}-{steps.required-variables.outputs.branch} ie. 20.0.0-Nexus
       # - release body: {steps.required-variables.outputs.changes}
       - name: Create Release
         id: create-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
         working-directory: ${{ github.event.repository.name }}
 
       # Create a release at {steps.required-variables.outputs.branch}
-      # - tag and release name format: {steps.required-variables.outputs.version}-{steps.required-variables.outputs.branch} ie. 1.0.0-Matrix
+      # - tag and release name format: {steps.required-variables.outputs.version}-{steps.required-variables.outputs.branch} ie. 20.0.0-Nexus
       # - release body: {steps.required-variables.outputs.changes}
       - name: Create Release
         id: create-release

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix")
+buildPlugin(version: "Nexus")

--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="2.9.4"
+  version="20.0.0"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -25,6 +25,16 @@
       <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
     </assets>
     <news>
+- 20.0.0
+  - Translations updates from Weblate
+    - ko_kr
+    - Changed to allow also addon.xml content update by Weblate
+  - Cleanup and improve Debian packaging
+  - Minor cleanup on addon.xml (change en_US to en_GB)
+  - Changed test builds to 'Kodi 20 Nexus'
+  - Increased version to 20.0.0
+    - With start of Kodi 20 Nexus, takes addon as major the same version number as Kodi.
+      This done to know easier to which Kodi the addon works.
 - 2.9.4 Set PVR Addon User-Agent
 - 2.9.2 Improve internal login handling
 - 2.9.1 Use UUIDv4 for device id


### PR DESCRIPTION
This change the Jenkins build to Kodi Nexus (where was not set before).

Version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.