### PR TITLE
[Nexus] Add supports recordings delete capability for PVR API 8.0.0

### DIFF
--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="20.0.0"
+  version="20.1.0"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -25,6 +25,7 @@
       <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
     </assets>
     <news>
+- 20.1.0 Kodi PVR API to 8.0.0
 - 20.0.0
   - Translations updates from Weblate
     - ko_kr

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -579,6 +579,7 @@ PVR_ERROR WaipuData::GetCapabilities(kodi::addon::PVRCapabilities& capabilities)
   capabilities.SetSupportsEPG(true);
   capabilities.SetSupportsTV(true);
   capabilities.SetSupportsRecordings(true);
+  capabilities.SetSupportsRecordingsDelete(true);
   capabilities.SetSupportsTimers(true);
   capabilities.SetSupportsChannelGroups(true);
 


### PR DESCRIPTION
- Kodi API to 8.0.0
  - Following in API change (not all affect addon):
    - Add supports recordings delete capability
    - Add support for PVR Providers and parental rating code for EPG
    - Enforce EDL limits

**WARNING:** Merge after the requests on Kodi are in.

This PR should be rebuilt via Jenkins after these xbmc PRs are merged:
- https://github.com/xbmc/xbmc/pull/20009
- https://github.com/xbmc/xbmc/pull/19395