### PR TITLE
Fix timers import on broken timer entry

### DIFF
--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -1931,6 +1931,13 @@ PVR_ERROR WaipuData::GetTimers(kodi::addon::PVRTimersResultSet& results)
 
   for (const auto& timer : timersDoc["result"].GetArray())
   {
+    // skip if missing epgdata
+    if (!timer.HasMember("epgData"))
+    {
+      kodi::Log(ADDON_LOG_DEBUG, "[timers] Skip due to missing epgData");
+      continue;
+    }
+
     // skip not FINISHED entries
     std::string status = timer["status"].GetString();
     if (status != "SCHEDULED" && status != "RECORDING")


### PR DESCRIPTION
It seems that waipu sometimes/rarely returns timers that have no EPG data set. Our timer import fails in this case.

This pr hopefully fixes #354 