### PR TITLE
Show error message when credentials are invalid

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,10 @@ For any support regarding this plugin, please create a github issue.
 
 1. `git clone --branch master https://github.com/xbmc/xbmc.git`
 2. `git clone --branch Piers https://github.com/flubshi/pvr.waipu.git`
-3. `cd pvr.waipu && mkdir build && cd build`
-4. `cmake -DADDONS_TO_BUILD=pvr.waipu -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
-5. `make`
+3. Build Kodi first
+4. `cd pvr.waipu && mkdir build && cd build`
+5. `cmake -DADDONS_TO_BUILD=pvr.waipu -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=<Kodi-build-dir>/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
+6. `make`
 
 
 ## Useful links

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -201,6 +201,8 @@ void WaipuData::LoginThread()
       }
 
       continue;
+    } else if (m_login_status == WAIPU_LOGIN_STATUS::INVALID_CREDENTIALS) {
+       kodi::QueueNotification(QUEUE_ERROR, "", kodi::addon::GetLocalizedString(30030));
     }
 
     kodi::addon::CInstancePVRClient::ConnectionStateChange("Connecting",


### PR DESCRIPTION
For regular users it is too complicated to investigate the JSON result from the HTTP request in the debug log.
Showing the message in the UI makes it more obvious.