### PR TITLE
update CMakeLists.txt cmake_minimum_required to 3.18

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18)
 project(pvr.waipu)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})


### PR DESCRIPTION
Aligns with min CMake version used in Kodi.

Fixes build warning when building with Cmake 4.x

    CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
      Compatibility with CMake < 3.10 will be removed from a future version of CMake.