### PR TITLE
fix: correct member declaration order in HttpGetRequests and initialize tag_channel

### DIFF
--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -1449,8 +1449,8 @@ struct HttpGetRequests
     f = std::async(std::launch::async, [&]() { return request->HttpGet(url); });
   }
 
-  WaipuData* request;
   std::string url;
+  WaipuData* request;
   std::future<std::string> f;
   T data;
 };
@@ -2126,7 +2126,7 @@ PVR_ERROR WaipuData::GetTimers(kodi::addon::PVRTimersResultSet& results)
     kodi::Log(ADDON_LOG_DEBUG, "[timers] Add: %s;", rec_title.c_str());
     tag.SetTitle(rec_title);
 
-    int tag_channel;
+    int tag_channel = PVR_CHANNEL_INVALID_UID;
     // channelid
     if (timer.contains("stationId") && !timer["stationId"].is_null())
     {


### PR DESCRIPTION
Fixes build warnings
```c++
../src/WaipuData.cpp: In instantiation of 'HttpGetRequests<T>::HttpGetRequests(WaipuData*, const std::string&, T) [with T = WaipuData::WaipuChannel; std::string = std::__cxx11::basic_string<char>]':
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/16.0.1/bits/stl_construct.h:110:9:   required from 'constexpr _Tp* std::construct_at(_Tp*, _Args&& ...) [with _Tp = HttpGetRequests<WaipuData::WaipuChannel>; _Args = {WaipuData*, const __cxx11::basic_string<char, char_traits<char>, allocator<char> >&, WaipuData::WaipuChannel&}]'
  110 |         return ::new(__loc) _Tp(std::forward<_Args>(__args)...);
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/16.0.1/bits/alloc_traits.h:716:21:   required from 'static constexpr void std::allocator_traits<std::allocator<_CharT> >::construct(allocator_type&, _Up*, _Args&& ...) [with _Up = HttpGetRequests<WaipuData::WaipuChannel>; _Args = {WaipuData*, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, WaipuData::WaipuChannel&}; _Tp = HttpGetRequests<WaipuData::WaipuChannel>; allocator_type = std::allocator<HttpGetRequests<WaipuData::WaipuChannel> >]'
  716 |           std::construct_at(__p, std::forward<_Args>(__args)...);
      |           ~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/include/c++/16.0.1/bits/vector.tcc:121:30:   required from 'constexpr std::vector<_Tp, _Alloc>::reference std::vector<_Tp, _Alloc>::emplace_back(_Args&& ...) [with _Args = {WaipuData*, const std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, WaipuData::WaipuChannel&}; _Tp = HttpGetRequests<WaipuData::WaipuChannel>; _Alloc = std::allocator<HttpGetRequests<WaipuData::WaipuChannel> >; reference = HttpGetRequests<WaipuData::WaipuChannel>&]'
  121 |             _Alloc_traits::construct(this->_M_impl, this->_M_impl._M_finish,
      |             ~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  122 |                                      std::forward<_Args>(__args)...);
      |                                      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/WaipuData.cpp:1498:28:   required from here
 1498 |       requests.emplace_back(this, url, channel->second);
      |       ~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~
../src/WaipuData.cpp:1453:15: warning: 'HttpGetRequests<WaipuData::WaipuChannel>::url' will be initialized after [-Wreorder]
 1453 |   std::string url;
      |               ^~~
../src/WaipuData.cpp:1452:14: warning:   'WaipuData* HttpGetRequests<WaipuData::WaipuChannel>::request' [-Wreorder]
 1452 |   WaipuData* request;
      |              ^~~~~~~
../src/WaipuData.cpp:1442:3: warning:   when initialized here [-Wreorder]
 1442 |   HttpGetRequests(WaipuData* request, const std::string& url, T data)
      |   ^~~~~~~~~~~~~~~
In file included from /var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/kodi/addon-instance/PVR.h:21,
                 from ../src/WaipuData.h:29,
                 from ../src/WaipuData.cpp:38:
In member function 'void kodi::addon::PVRTimer::SetClientChannelUid(int)',
    inlined from 'virtual PVR_ERROR WaipuData::GetTimers(kodi::addon::PVRTimersResultSet&)' at ../src/WaipuData.cpp:2160:37:
/var/media/DATA/home-rudi/LibreELEC.tv/build.LibreELEC-Generic.x86_64-13.0-devel/toolchain/x86_64-libreelec-linux-gnu/sysroot/usr/include/kodi/addon-instance/pvr/Timers.h:185:37: warning: 'tag_channel' may be used uninitialized [-Wmaybe-uninitialized]
  185 |     m_cStructure->iClientChannelUid = clientChannelUid;
      |     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~
../src/WaipuData.cpp: In member function 'virtual PVR_ERROR WaipuData::GetTimers(kodi::addon::PVRTimersResultSet&)':
../src/WaipuData.cpp:2129:9: note: 'tag_channel' was declared here
 2129 |     int tag_channel;
      |         ^~~~~~~~~~~
``` 