### PR TITLE
Load EPG details for top 12 recently watched channels

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,7 @@ set(PVRWAIPU_SOURCES
                     src/HLSAllowlist.cpp
                     src/Base64.cpp
                     src/JWT.cpp
+                    src/LRUChannels.cpp
                     src/MDNS.cpp
                     src/categories.cpp
                     src/WaipuData.cpp)
@@ -25,6 +26,7 @@ set(PVRWAIPU_HEADERS
                     src/HLSAllowlist.h
                     src/Base64.h
                     src/JWT.h
+                    src/LRUChannels.h
                     src/MDNS.h
                     src/SynchronizedQueue.h
                     src/categories.h

--- a/pvr.waipu/addon.xml.in
+++ b/pvr.waipu/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="pvr.waipu"
-  version="22.9.5"
+  version="22.10.0"
   name="waipu.tv PVR Client"
   provider-name="flubshi">
   <requires>@ADDON_DEPENDS@
@@ -26,12 +26,8 @@
       <screenshot>resources/screenshots/screenshot-02.jpg</screenshot>
     </assets>
     <news>
-v22.9.5
-- Fix playback of VoD channels in auto stream selection mode
-
-v22.9.4
-- Fix handling of invalid credentials
-- Allow user to cancel recording creation
+v22.10.0
+- Load EPG details for top 12 recently watched channels
     </news>
     <summary lang="bs_BA">waipu.tv PVR klijent</summary>
     <summary lang="cs_CZ">Klient PVR pro waipu.tv</summary>

--- a/src/LRUChannels.cpp
+++ b/src/LRUChannels.cpp
@@ -1,0 +1,124 @@
+/*
+ *      Copyright (C) 2026 flubshi
+ *      https://github.com/flubshi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include "LRUChannels.h"
+
+#include "Utils.h"
+#include "kodi/Filesystem.h"
+
+#include <nlohmann/json.hpp>
+
+void LRUChannels::Touch(const std::string& waipuID)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  // if already tracked, remove from current position first
+  const auto it = m_set.find(waipuID);
+  if (it != m_set.end())
+  {
+    m_list.remove(waipuID);
+  }
+  else
+  {
+    // evict least recently played channel if at capacity
+    if (m_list.size() >= MAX_SIZE)
+    {
+      m_set.erase(m_list.back());
+      m_list.pop_back();
+    }
+    m_set.insert(waipuID);
+  }
+
+  m_list.push_front(waipuID);
+  kodi::Log(ADDON_LOG_DEBUG, "[lru] touched channel %s (list size: %zu)", waipuID.c_str(),
+            m_list.size());
+}
+
+bool LRUChannels::Contains(const std::string& waipuID) const
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+  return m_set.count(waipuID) > 0;
+}
+
+void LRUChannels::Load(const std::string& filePath)
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  const std::string content = Utils::ReadFile(filePath);
+  if (content.empty())
+  {
+    kodi::Log(ADDON_LOG_DEBUG, "[lru] no LRU channel list found at %s", filePath.c_str());
+    return;
+  }
+
+  nlohmann::json arr;
+  try
+  {
+    arr = nlohmann::json::parse(content);
+  }
+  catch (const nlohmann::json::parse_error&)
+  {
+    kodi::Log(ADDON_LOG_ERROR, "[lru] ERROR: failed to parse LRU channel list at %s",
+              filePath.c_str());
+    return;
+  }
+
+  if (!arr.is_array())
+  {
+    kodi::Log(ADDON_LOG_ERROR, "[lru] ERROR: LRU channel list is not a JSON array");
+    return;
+  }
+
+  m_list.clear();
+  m_set.clear();
+
+  for (const auto& entry : arr)
+  {
+    if (!entry.is_string())
+      continue;
+    if (m_list.size() >= MAX_SIZE)
+      break;
+    const std::string waipuID = entry.get<std::string>();
+    m_list.push_back(waipuID);
+    m_set.insert(waipuID);
+  }
+
+  kodi::Log(ADDON_LOG_DEBUG, "[lru] loaded %zu channel(s) from %s", m_list.size(),
+            filePath.c_str());
+}
+
+void LRUChannels::Save(const std::string& filePath) const
+{
+  std::lock_guard<std::mutex> lock(m_mutex);
+
+  const nlohmann::json arr(m_list);
+  const std::string content = arr.dump();
+
+  kodi::vfs::CFile file;
+  if (!file.OpenFileForWrite(filePath, true))
+  {
+    kodi::Log(ADDON_LOG_ERROR, "[lru] ERROR: failed to open %s for writing", filePath.c_str());
+    return;
+  }
+
+  file.Write(content.data(), content.size());
+  kodi::Log(ADDON_LOG_DEBUG, "[lru] saved %zu channel(s) to %s", m_list.size(), filePath.c_str());
+}

--- a/src/LRUChannels.h
+++ b/src/LRUChannels.h
@@ -1,0 +1,56 @@
+#pragma once
+/*
+ *      Copyright (C) 2026 flubshi
+ *      https://github.com/flubshi
+ *
+ *  This Program is free software; you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation; either version 2, or (at your option)
+ *  any later version.
+ *
+ *  This Program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with XBMC; see the file COPYING.  If not, write to
+ *  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+ *  http://www.gnu.org/copyleft/gpl.html
+ *
+ */
+
+#include <list>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+
+// Tracks the last MAX_SIZE played channels by waipu station ID.
+// Used to enable EPG detail fetching for recently played channels,
+// analogous to the favorite channels mechanism.
+class LRUChannels
+{
+public:
+  // Maximum number of channels tracked in the LRU list
+  static constexpr size_t MAX_SIZE = 12;
+
+  // Move waipuID to the front of the list (most recently played).
+  // If the channel is not yet in the list, it is added. If the list
+  // is at capacity, the least recently played channel is evicted.
+  void Touch(const std::string& waipuID);
+
+  // Returns true if waipuID is currently in the LRU list.
+  bool Contains(const std::string& waipuID) const;
+
+  // Loads the LRU list from a JSON file at filePath.
+  // Silently does nothing if the file does not exist or cannot be parsed.
+  void Load(const std::string& filePath);
+
+  // Saves the current LRU list as a JSON array to filePath.
+  void Save(const std::string& filePath) const;
+
+private:
+  mutable std::mutex m_mutex;
+  std::list<std::string> m_list; // front = most recently played
+  std::unordered_set<std::string> m_set; // O(1) membership check
+};

--- a/src/WaipuData.cpp
+++ b/src/WaipuData.cpp
@@ -1133,6 +1133,9 @@ PVR_ERROR WaipuData::GetChannelStreamProperties(
   if (!strUrl.empty())
   {
     SetStreamProperties(properties, strUrl, true, false, protocol);
+    const auto& lruChannel = m_channels.find(channel.GetUniqueId());
+    if (lruChannel != m_channels.end())
+      m_lruChannels.Touch(lruChannel->second.waipuID);
     ret = PVR_ERROR_NO_ERROR;
   }
   return ret;
@@ -1568,10 +1571,11 @@ PVR_ERROR WaipuData::GetEPGForChannel(int channelUid,
 
     for (const auto& epgData : epgDoc)
     {
-      // we limit epg details fetching to channel.isFavorite, because it takes a lot of time
+      // we limit epg details fetching to favorite channels and recently played channels (LRU),
+      // because it takes a lot of time
       const auto& channel = request.data;
-      results.Add(
-          ParseEPGTagEntry(epgData, channel.iUniqueId, channel.waipuID, channel.isFavorite));
+      results.Add(ParseEPGTagEntry(epgData, channel.iUniqueId, channel.waipuID,
+                                   channel.isFavorite || m_lruChannels.Contains(channel.waipuID)));
     }
   }
 
@@ -1719,6 +1723,9 @@ PVR_ERROR WaipuData::GetEPGTagStreamProperties(
   }
 
   SetStreamProperties(properties, strUrl, true, true, protocol);
+
+  if (thisChannel != m_channels.end())
+    m_lruChannels.Touch(thisChannel->second.waipuID);
 
   return PVR_ERROR_NO_ERROR;
 }
@@ -2394,6 +2401,8 @@ PVR_ERROR WaipuData::AddTimer(const kodi::addon::PVRTimer& timer)
 
 WaipuData::~WaipuData()
 {
+  m_lruChannels.Save(Utils::GetFilePath("lru_channels.json"));
+
   m_loginThreadRunning = false;
   m_loginCv.notify_one();
   if (m_loginThread.joinable())
@@ -2415,6 +2424,8 @@ ADDON_STATUS WaipuData::Create()
       Utils::Replace(ua, " ", std::string(" pvr.waipu/").append(STR(IPTV_VERSION)).append(" "));
 
   ReadSettings();
+
+  m_lruChannels.Load(Utils::GetFilePath("lru_channels.json"));
 
   if (m_provider == WAIPU_PROVIDER_WAIPU && (m_username.empty() || m_password.empty()))
   {

--- a/src/WaipuData.h
+++ b/src/WaipuData.h
@@ -23,6 +23,7 @@
 #include "Curl.h"
 #include "HLSAllowlist.h"
 #include "JWT.h"
+#include "LRUChannels.h"
 #include "SynchronizedQueue.h"
 #include "categories.h"
 #include "kodi/Network.h"
@@ -207,6 +208,7 @@ private:
   std::atomic<WAIPU_LOGIN_STATUS> m_login_status{WAIPU_LOGIN_STATUS::UNKNOWN};
   HLSAllowlist m_hls_allowlist;
   Categories m_categories;
+  LRUChannels m_lruChannels;
   time_t m_lastUpdate = 0;
 
   void ReadSettings();


### PR DESCRIPTION
Currently, we only fetch epg details for channels marked as favorite.

With this PR, we store the recently watched channels and fetch EPG details if a channel is favorite or watched recently.